### PR TITLE
Remove automated cert-manager install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "engines": {
     "node": ">=12"

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -15,6 +15,9 @@ kubewarden:
       certManager:
         title: Install Cert-Manager Package
         description: The kubewarden-controller depends on cert-manager. You need cert-manager to be installed before installing the kubewarden-controller chart.
+        manualStep: |
+          Follow the <a target="_blank" rel="noopener noreferrer nofollow" href="https://docs.kubewarden.io/quick-start#installation">Documentation</a>, or run the <code>kubectl</code> command below on to install the latest version of cert-manager:
+        applyCommand: 'kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml'
       repository:
         title: Repository
         description: You will need the Kubewarden helm repository (https://charts.kubewarden.io) to install the `kubewarden` chart.

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "rancher": true,
   "scripts": {

--- a/pkg/kubewarden/plugins/kubewarden/policy-class.js
+++ b/pkg/kubewarden/plugins/kubewarden/policy-class.js
@@ -3,10 +3,11 @@ import flatMap from 'lodash/flatMap';
 import matches from 'lodash/matches';
 
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { SERVICE } from '@shell/config/types';
+import { MANAGEMENT, SERVICE } from '@shell/config/types';
 import { proxyUrlFromParts } from '@shell/models/service';
 import { findBy, isArray } from '@shell/utils/array';
 import { addParam } from '@shell/utils/url';
+
 import { KUBEWARDEN } from '../../types';
 
 export const TRACE_HEADERS = [
@@ -462,4 +463,31 @@ export function stateSort(color, display) {
   color = color.replace(/^(text|bg)-/, '');
 
   return `${ SORT_ORDER[color] || SORT_ORDER['other'] } ${ display }`;
+}
+
+export async function updateWhitelist(url, remove) {
+  const whitelist = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: 'whitelist-domain' });
+  const whitelistValue = whitelist.value.split(',');
+
+  if ( remove && whitelistValue.includes(url) ) {
+    const out = whitelistValue.filter(domain => domain !== url);
+
+    whitelist.default = out.join();
+    whitelist.value = out.join();
+
+    try {
+      return whitelist.save();
+    } catch (e) {}
+  }
+
+  if ( !whitelistValue.includes(url) ) {
+    whitelistValue.push(url);
+
+    whitelist.default = whitelistValue.join();
+    whitelist.value = whitelistValue.join();
+
+    try {
+      return whitelist.save();
+    } catch (e) {}
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #112 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This removes the automated step for cert-manager install and replaces it with a link to the documentation and a `kubectl` command for applying the resource.

## Test
On a fresh install of the extension, go to the Kubewarden overview page and begin installation.

![1st-step](https://user-images.githubusercontent.com/40806497/197830682-6b67d75b-54f0-414e-963f-e0d0bea8dc74.png)
