### PR TITLE
Add whitelist button to policy creation - fix overlapping text

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -69,6 +69,7 @@ kubewarden:
     title: Custom Policy
     description: A generic template for using your own policy.
   policies:
+    noArtifactHub: Official Kubewarden policies are hosted on ArtifactHub, in order to show these you will need to add `artifacthub.io` to the whitelist-domain setting.
     noRules: There are no rules configured for this policy.
     namespaceWarning: This policy is targeting Rancher specific namespaces which will cause catastrophic failures with your Rancher deployment.
   utils:
@@ -320,6 +321,10 @@ kubewarden:
         Pod
 
 asyncButton:
+  artifactHub:
+    action: Add ArtifactHub To Whitelist
+    success: Added
+    waiting: Adding&hellip;
   certManager:
     action: Apply Cert-Manager Package
     success: Applied

--- a/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
+++ b/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
@@ -8,7 +8,7 @@ import CopyCode from '@shell/components/CopyCode';
 import Loading from '@shell/components/Loading';
 
 import { KUBEWARDEN } from '../../../../types';
-import { updateWhitelist } from '../../../../plugins/kubewarden/policy-class';
+// import { updateWhitelist } from '../../../../plugins/kubewarden/policy-class';
 
 import InstallWizard from '../../../../components/overview/InstallWizard';
 
@@ -116,7 +116,7 @@ export default {
 
         const yaml = res?.data;
 
-        await updateWhitelist('github.com', true);
+        // await updateWhitelist('github.com', true);
         await this.currentCluster.doAction('apply', { yaml, defaultNamespace: 'cert-manager' });
 
         btnCb(true);


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #111 - Fix #113

This removes the whitelist setting from being added automatically on the kubewarden installation page and adds a banner to the policy creation page which if not found will allow the user to add the setting.
This also fixes the overlapping text for policies targeting multiple resources and adds the "Multiple" tag in place.

_Whitelist banner_
![whitelist](https://user-images.githubusercontent.com/40806497/198025302-c39efc4a-555b-4b6a-bc68-46ebe1ebf32e.png)

_Multiple resource tag_
![multiple](https://user-images.githubusercontent.com/40806497/198025365-f198c94d-c9db-4447-9ed0-905d248464f9.png)

