### PR TITLE
Add banner to PolicyServer list page for default chart installation

### DIFF
--- a/pkg/kubewarden/components/RulesTable.vue
+++ b/pkg/kubewarden/components/RulesTable.vue
@@ -22,7 +22,6 @@ export default {
     joinColumn(resource) {
       return resource?.join(', ') || '';
     }
-
   }
 };
 </script>
@@ -40,13 +39,13 @@ export default {
     >
       <template #col:apiGroup="{row}">
         <td>
-          <span>{{ row.apiGroups }}</span>
+          <span>{{ row.apiGroups || '-' }}</span>
         </td>
       </template>
 
       <template #col:apiVersion="{row}">
         <td>
-          <span>{{ row.apiVersions }}</span>
+          <span>{{ row.apiVersions || '-' }}</span>
         </td>
       </template>
 

--- a/pkg/kubewarden/components/policies/Create.vue
+++ b/pkg/kubewarden/components/policies/Create.vue
@@ -201,7 +201,11 @@ export default ({
 
     async finish(event) {
       try {
-        // This won't be necessary if we can get the policy to automatically apply a default value for this property
+        /*
+          This empty string is necessary for the policy to become active.
+          TODO: open issue to fix this on kubewarden side, should be able to have null
+                for apiGroups and apiVersions
+        */
         if ( isEmpty(this.chartValues?.policy?.spec?.rules[0]?.apiGroups) ) {
           this.chartValues.policy.spec.rules[0].apiGroups.push('');
         }
@@ -422,7 +426,7 @@ $color: var(--body-text) !important;
     position: absolute;
     right: 0;
     top: 0;
-    padding: 2px $padding;
+    padding: 4px $padding;
     border-bottom-left-radius: var(--border-radius);
 
     label {

--- a/pkg/kubewarden/components/policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/policies/PolicyGrid.vue
@@ -206,8 +206,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-$padding: 5px;
-$height: 110px;
 $margin: 10px;
 
 .step {
@@ -292,6 +290,7 @@ $margin: 10px;
 .subtype {
   &__badge {
     background-color: var(--darker);
+    padding: 4px 5px;
   }
 
   &__signed, &__mutation, &__aware {

--- a/pkg/kubewarden/detail/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.admissionpolicy.vue
@@ -117,7 +117,7 @@ export default {
       <h3>{{ t('namespace.resources') }}</h3>
     </div>
     <ResourceTabs v-model="value" :mode="mode" :need-related="hasRelationships">
-      <Tab name="policy-rules" label="Rules" :weight="99">
+      <Tab v-if="!!rulesRows" name="policy-rules" label="Rules" :weight="99">
         <RulesTable :rows="rulesRows" />
       </Tab>
       <Tab name="policy-tracing" label="Tracing" :weight="98">

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -58,6 +58,10 @@ kubewarden:
           placeholder: all-in-one-collector.jaeger.svc.cluster.local:14250
   policyServer:
     title: Policy Servers
+    noDefaultsInstalled:
+      description: |
+        The default PolicyServer and policies are not installed, click the button below to begin installing this chart. See the <a target="_blank" rel="noopener noreferrer nofollow" href="https://docs.kubewarden.io/quick-start#installation">documentation</a> for more information on installing charts.
+      button: Install Chart
   admissionPolicy:
     title: Admission Policies
     description: AdmissionPolicy is a namespace-wide resource. These policies will process only the requests that are targeting the Namespace where the AdmissionPolicy is defined.
@@ -134,7 +138,7 @@ kubewarden:
         file: Read Certificate from File
     verification:
       label: Verification Config
-      description: This is the name of a VerificationConfig configmap within the same namespace, containing a Sigstore verification configuration. The configuration must be under a key named verification-config in the Configmap. More information can be found <a href="https://docs.kubewarden.io/distributing-policies/secure-supply-chain#configuring-the-policy-server-to-check-policy-signatures" target="_blank" rel="noopener noreferrer nofollow">here</a>.
+      description: This is the name of a VerificationConfig configmap within the same namespace, containing a Sigstore verification configuration. The configuration must be under a key named verification-config in the Configmap. More information can be found in the <a href="https://docs.kubewarden.io/distributing-policies/secure-supply-chain#configuring-the-policy-server-to-check-policy-signatures" target="_blank" rel="noopener noreferrer nofollow">Kubewarden docs</a>.
   policyCharts:
     signedPolicy: This policy has been signed with cosign (Sigstore).
     mutationPolicy: Mutation Policy

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -1,0 +1,87 @@
+<script>
+import { CATALOG } from '@shell/config/types';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+
+import { Banner } from '@components/Banner';
+import Loading from '@shell/components/Loading';
+import ResourceTable from '@shell/components/ResourceTable';
+
+export default {
+  components: {
+    Banner, Loading, ResourceTable
+  },
+
+  props: {
+    resource: {
+      type:     String,
+      required: true,
+    },
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    this.rows = await this.$store.dispatch('cluster/findAll', { type: this.resource });
+
+    await this.$store.dispatch('catalog/load');
+
+    // Determine if the default PolicyServer is installed from the `kubewarden-defaults` chart
+    const apps = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+
+    this.hasDefaults = apps.find((a) => {
+      return a.spec.chart.metadata.annotations[CATALOG_ANNOTATIONS.RELEASE_NAME] === 'rancher-kubewarden-defaults';
+    });
+  },
+
+  data() {
+    return {
+      hasDefaults: null,
+      rows:        null
+    };
+  },
+
+  methods: {
+    setChartRoute() {
+      // Check to see that `kubewarden-defaults` chart is available
+      const charts = this.$store.getters['catalog/rawCharts'];
+      const chartValues = Object.values(charts);
+
+      const controllerChart = chartValues.find(
+        chart => chart.chartName === 'kubewarden-defaults'
+      );
+
+      if ( controllerChart ) {
+        return controllerChart.goToInstall('kubewarden-defaults');
+      }
+
+      return null;
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <Banner
+      v-if="!hasDefaults"
+      class="mb-20 mt-0"
+      color="info"
+      :closable="true"
+    >
+      <p v-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)"></p>
+      <button
+        class="btn role-primary mt-10"
+        @click.prevent="setChartRoute"
+      >
+        {{ t("kubewarden.policyServer.noDefaultsInstalled.button") }}
+      </button>
+    </Banner>
+    <ResourceTable
+      :schema="schema"
+      :rows="rows"
+    />
+  </div>
+</template>

--- a/pkg/kubewarden/plugins/kubewarden/policy-class.js
+++ b/pkg/kubewarden/plugins/kubewarden/policy-class.js
@@ -88,9 +88,10 @@ export const MODE_MAP = {
 };
 
 export const OPERATION_MAP = {
-  CREATE: 'bg-info',
-  UPDATE: 'bg-warning',
-  DELETE: 'bg-error'
+  CREATE:  'bg-info',
+  UPDATE:  'bg-warning',
+  DELETE:  'bg-error',
+  CONNECT: 'bg-success'
 };
 
 export const RANCHER_NAMESPACES = [


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #121 

This adds a banner to the PolicyServer list page which checks for the `kubewarden-defaults` chart that includes the default policy server and gives a link to install the chart.
Also fixes an issue with determining the `apiVersions` to list in a policy's rule set, depending on the resource selected or apiGroup selected.