### PR TITLE
Make apiGroups rule required - add * to options

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rule.vue
@@ -34,7 +34,6 @@ export default {
 
   fetch() {
     this.inStore = this.$store.getters['currentStore']();
-
     this.schemas = this.$store.getters[`${ this.inStore }/all`](SCHEMA);
   },
 
@@ -63,21 +62,23 @@ export default {
 
   computed: {
     apiGroupOptions() {
-      if ( !isEmpty(this.apiGroups) ) {
-        const out = [];
+      const out = ['*'];
 
+      if ( !isEmpty(this.apiGroups) ) {
         this.apiGroups.map(g => out.push(g.id));
 
         return out;
       }
 
-      return this.apiGroups;
+      out.push(this.apiGroups);
+
+      return out;
     },
 
     apiVersionOptions() {
       let out = [];
 
-      if ( !isEmpty(this.value?.apiGroups) ) {
+      if ( !isEmpty(this.value?.apiGroups) && !this.isGroupCore ) {
         out = this.apiVersions(this.value.apiGroups, true);
       } else if ( !isEmpty(this.value?.resources) ) {
         out = this.apiVersions(this.value.resources, false);
@@ -88,8 +89,9 @@ export default {
 
     isGroupCore() {
       const groups = this.value.apiGroups;
+      const options = ['core', '*', ''];
 
-      return groups.includes('core') || groups.includes('') ;
+      return options.some(o => groups.includes(o));
     },
 
     resourceOptions() {
@@ -164,6 +166,7 @@ export default {
         :mode="mode"
         :multiple="true"
         :options="apiGroupOptions || []"
+        :required="true"
       />
     </div>
 

--- a/pkg/kubewarden/components/policies/Create.vue
+++ b/pkg/kubewarden/components/policies/Create.vue
@@ -201,15 +201,6 @@ export default ({
 
     async finish(event) {
       try {
-        /*
-          This empty string is necessary for the policy to become active.
-          TODO: open issue to fix this on kubewarden side, should be able to have null
-                for apiGroups and apiVersions
-        */
-        if ( isEmpty(this.chartValues?.policy?.spec?.rules[0]?.apiGroups) ) {
-          this.chartValues.policy.spec.rules[0].apiGroups.push('');
-        }
-
         const { ignoreRancherNamespaces } = this.chartValues.policy;
 
         if ( ignoreRancherNamespaces ) {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #129

This adds the `*` option to the `apiGroups` input select and changes the input to be a required value. Removing/modifying the empty string from an existing policy is not necessary as '*' accomplishes the same behavior as an empty string.