### PR TITLE
Add formatter for policy server deployment errors

### DIFF
--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -118,7 +118,14 @@ export function init($plugin, store) {
 
   headers(POLICY_SERVER, [
     STATE,
-    NAME_HEADER,
+    {
+      name:          'name',
+      labelKey:      'tableHeaders.name',
+      value:         'nameDisplay',
+      sort:          ['nameSort'],
+      formatter:     'PolicyServerDeployment',
+      canBeVariable: true,
+    },
     {
       name:          'kubewardenPolicyServers',
       label:         'Image',

--- a/pkg/kubewarden/formatters/PolicyServerDeployment.vue
+++ b/pkg/kubewarden/formatters/PolicyServerDeployment.vue
@@ -1,0 +1,105 @@
+<script>
+import isEmpty from 'lodash/isEmpty';
+
+import { get } from '@shell/utils/object';
+
+export default {
+  props: {
+    reference: {
+      type:    String,
+      default: null,
+    },
+
+    row: {
+      type:     Object,
+      required: true
+    },
+
+    value: {
+      type:     String,
+      default: ''
+    }
+  },
+
+  async fetch() {
+    this.deployment = await this.row.matchingDeployment();
+  },
+
+  data() {
+    return { deployment: null };
+  },
+
+  computed:   {
+    hasErrors() {
+      const out = this.flattenedConditions?.filter(condition => condition.error);
+
+      return !isEmpty(out);
+    },
+
+    flattenedConditions() {
+      return this.deployment?.flatMap(dep => dep.status.conditions);
+    },
+
+    formattedConditions() {
+      if ( this.hasErrors ) {
+        const errorConditions = this.flattenedConditions.filter(condition => condition.error);
+        const formattedTooltip = [];
+
+        errorConditions?.forEach((c) => {
+          formattedTooltip.push(`<p><b>${ [c.type] }</b>: ${ c.message }</p>`);
+        });
+
+        return formattedTooltip.toString().replaceAll(',', '');
+      }
+
+      return false;
+    },
+
+    to() {
+      if ( this.row && this.reference ) {
+        return get(this.row, this.reference);
+      }
+
+      return this.row?.detailLocation;
+    },
+  },
+
+};
+
+</script>
+<template>
+  <span class="cluster-link">
+    <n-link v-if="to" :to="to">
+      {{ value }}
+    </n-link>
+    <span v-else>{{ value }}</span>
+    <i
+      v-if="hasErrors"
+      v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
+      class="conditions-alert-icon icon-error icon-lg"
+    />
+  </span>
+</template>
+
+<style lang="scss" scoped>
+  .cluster-link {
+    display: flex;
+    align-items: center;
+  }
+
+  .conditions-alert-icon {
+    color: var(--error);
+    margin-left: 4px;
+  }
+
+  ::v-deep {
+    .labeled-tooltip, .status-icon {
+      position: relative;
+      display: inline;
+      left: auto;
+      right: auto;
+      top: 2px;
+      bottom: auto;
+    }
+  }
+</style>

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -31,7 +31,7 @@ export default {
     const apps = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
 
     this.hasDefaults = apps.find((a) => {
-      return a.spec.chart.metadata.annotations[CATALOG_ANNOTATIONS.RELEASE_NAME] === 'rancher-kubewarden-defaults';
+      return a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === 'rancher-kubewarden-defaults';
     });
   },
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #131 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This fixes the issue of opening the logs of from a failed deployment of PolicyServer and adds an notification icon next to the policy server which has an error condition.

![error](https://user-images.githubusercontent.com/40806497/199322724-7d1c91e8-74c5-44a1-950f-105e79181b3c.png)

