### PR TITLE
Add empty Yaml for custom policy settings

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -3,9 +3,8 @@ name: Build Kubewarden Extension
 on:
   push:
     branches: [main]
-    paths-ignore:
-      # - ".github/workflows/**"
-      - "README.md"
+    paths:
+      - pkg/kubewarden/package.json
     
 env:
   ACTIONS_RUNNER_DEBUG: false

--- a/pkg/kubewarden/components/policies/Values.vue
+++ b/pkg/kubewarden/components/policies/Values.vue
@@ -37,9 +37,9 @@ export default {
       type:     Object,
       required: true
     },
-    hasReadme: {
-      type:     Boolean,
-      default:  false
+    customPolicy: {
+      type:    Boolean,
+      default: false
     },
     value: {
       type:     Object,
@@ -152,6 +152,7 @@ export default {
               :is="valuesComponent"
               v-model="chartValues"
               :mode="mode"
+              :custom-policy="customPolicy"
             />
           </Tabbed>
         </template>


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #140 

This adds an empty Yaml input for the settings when creating custom policies.

