### PR TITLE
Fix overview page route

### DIFF
--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -42,7 +42,7 @@ export default {
 <template>
   <div v-if="!monitoringStatus.installed">
     <Banner color="warning">
-      <span v-html="t('kubewarden.monitoring.notInstalled', true)" />
+      <span v-html="t('kubewarden.monitoring.notInstalled', {}, true)" />
       <nuxt-link :to="monitoringRoute">
         {{ t('kubewarden.monitoring.install') }}
       </nuxt-link>

--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -3,6 +3,7 @@ import {
   KUBEWARDEN,
   KUBEWARDEN_DASHBOARD
 } from '../types';
+import { rootKubewardenRoute } from '../utils/custom-routing';
 
 export const CHART_NAME = 'rancher-kubewarden';
 
@@ -56,7 +57,7 @@ export function init($plugin, store) {
     name:        KUBEWARDEN_DASHBOARD,
     namespaced:  false,
     weight:      99,
-    route:      { name: 'c-cluster-kubewarden' },
+    route:       rootKubewardenRoute(),
     overview:    true
   });
   basicType([KUBEWARDEN_DASHBOARD]);

--- a/pkg/kubewarden/routes/kubewarden-routes.ts
+++ b/pkg/kubewarden/routes/kubewarden-routes.ts
@@ -9,7 +9,7 @@ import ViewKubewardenNsResource from '../pages/c/_cluster/kubewarden/_resource/_
 const routes = [
   {
     name:       `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
-    path:       `/c/:cluster/kubewarden`,
+    path:       `/c/:cluster/:product/dashboard`,
     component:  ListKubewarden,
   },
   {

--- a/pkg/kubewarden/utils/custom-routing.ts
+++ b/pkg/kubewarden/utils/custom-routing.ts
@@ -1,0 +1,6 @@
+import { KUBEWARDEN_PRODUCT_NAME } from '../types';
+
+export const rootKubewardenRoute = () => ({
+  name:    `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
+  params: { product: KUBEWARDEN_PRODUCT_NAME }
+});


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #156 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This adds the route `/c/:cluster/:product/dashboard` to the routing config along with a `rootKubewardenRoute` method to pass the params necessary for proper routing.

