### PR TITLE
Consolidate installation steps

### DIFF
--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -3,7 +3,6 @@ import {
   KUBEWARDEN,
   KUBEWARDEN_DASHBOARD
 } from '../types';
-import { rootKubewardenRoute } from '../utils/custom-routing';
 
 export const CHART_NAME = 'rancher-kubewarden';
 
@@ -57,10 +56,9 @@ export function init($plugin, store) {
     name:        KUBEWARDEN_DASHBOARD,
     namespaced:  false,
     weight:      99,
-    route:       rootKubewardenRoute(),
+    route:       { name: 'c-cluster-kubewarden' },
     overview:    true
   });
-  basicType([KUBEWARDEN_DASHBOARD]);
 
   /*
     TODO: remove these when rancher-charts integration is complete
@@ -108,6 +106,7 @@ export function init($plugin, store) {
   });
 
   basicType([
+    KUBEWARDEN_DASHBOARD,
     POLICY_SERVER,
     ADMISSION_POLICY,
     CLUSTER_ADMISSION_POLICY

--- a/pkg/kubewarden/routes/kubewarden-routes.ts
+++ b/pkg/kubewarden/routes/kubewarden-routes.ts
@@ -1,6 +1,6 @@
 import { KUBEWARDEN_PRODUCT_NAME } from '../types';
 
-import ListKubewarden from '../pages/c/_cluster/kubewarden/index.vue';
+import Dashboard from '../pages/c/_cluster/kubewarden/index.vue';
 import KubewardenResourcedList from '../pages/c/_cluster/kubewarden/_resource/index.vue';
 import CreateKubewardenResource from '../pages/c/_cluster/kubewarden/_resource/create.vue';
 import ViewKubewardenResource from '../pages/c/_cluster/kubewarden/_resource/_id.vue';
@@ -9,8 +9,8 @@ import ViewKubewardenNsResource from '../pages/c/_cluster/kubewarden/_resource/_
 const routes = [
   {
     name:       `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
-    path:       `/c/:cluster/:product/dashboard`,
-    component:  ListKubewarden,
+    path:       `/c/:cluster/:product`,
+    component:  Dashboard,
   },
   {
     name:       `c-cluster-product-resource`,

--- a/pkg/kubewarden/utils/custom-routing.ts
+++ b/pkg/kubewarden/utils/custom-routing.ts
@@ -1,6 +1,0 @@
-import { KUBEWARDEN_PRODUCT_NAME } from '../types';
-
-export const rootKubewardenRoute = () => ({
-  name:    `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
-  params: { product: KUBEWARDEN_PRODUCT_NAME }
-});


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #157, Fix #163 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This fixes the Install Chart button from being unresponsive by forcing a load of the current charts before the button is displayed, this will ensure that the chart exists that is routable.
Also consolidated the last two steps of the wizard. 


https://user-images.githubusercontent.com/40806497/206017441-89c4ada5-3d1a-41ed-8f42-4bc98ab693a2.mp4


