### PR TITLE
Add insight cards to policy server detail

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -2,7 +2,8 @@
 import isEmpty from 'lodash/isEmpty';
 import jsyaml from 'js-yaml';
 
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { saferDump } from '@shell/utils/create-yaml';
 
 import Questions from '@shell/components/Questions';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -31,20 +32,35 @@ export default {
     General, Questions, Rules, Tab, YamlEditor
   },
 
-  data() {
-    let chartValues = null;
-
+  fetch() {
     if ( this.value ) {
-      chartValues = this.value;
+      this.chartValues = this.value;
     }
 
-    return { chartValues };
+    if ( !isEmpty(this.chartValues?.policy?.spec?.settings) ) {
+      this.settingsYaml = saferDump(this.chartValues.policy.spec.settings);
+    }
+
+    if ( this.isCreate && this.isCustom ) {
+      this.settingsYaml = '# Additional Settings YAML \n';
+    }
+  },
+
+  data() {
+    return {
+      chartValues:  null,
+      settingsYaml: ''
+    };
   },
 
   computed: {
     hasSettings() {
-      if ( !this.isCustom ) {
-        return !!this.value?.policy?.spec?.settings && !isEmpty(this.value?.policy?.spec?.settings);
+      return !isEmpty(this.value?.policy?.spec?.settings);
+    },
+
+    hasQuestions() {
+      if ( !isEmpty(this.chartValues?.questions?.questions) ) {
+        return true;
       }
 
       return false;
@@ -56,6 +72,22 @@ export default {
 
     isCustom() {
       return this.customPolicy;
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+
+    showSettings() {
+      if ( this.isCreate && this.isCustom ) {
+        return true;
+      }
+
+      if ( this.hasSettings && !this.hasQuestions ) {
+        return true;
+      }
+
+      return false;
     },
 
     targetNamespace() {
@@ -86,19 +118,20 @@ export default {
       <Rules v-model="chartValues" :mode="mode" />
     </Tab>
 
-    <template v-if="isCreate && isCustom">
+    <template v-if="showSettings">
       <Tab name="settings" label="Settings" :weight="97">
         <YamlEditor
-          :v-model="value.policy.spec.settings"
-          initial-yaml-values="'# Additional Settings YAML \n\n'"
+          ref="yamleditor"
+          v-model="settingsYaml"
           class="yaml-editor"
+          :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"
           @onInput="settingsChanged($event)"
         />
       </Tab>
     </template>
 
     <!-- Values as questions -->
-    <template v-if="hasSettings">
+    <template v-if="hasQuestions">
       <Tab name="Settings" label="Settings" :weight="97">
         <Questions
           v-model="chartValues.policy.spec.settings"
@@ -111,3 +144,9 @@ export default {
     </template>
   </div>
 </template>
+
+<style lang="scss" scoped>
+::v-deep .CodeMirror-lines {
+    min-height: 40px;
+  }
+</style>

--- a/pkg/kubewarden/components/policies/Config.vue
+++ b/pkg/kubewarden/components/policies/Config.vue
@@ -1,5 +1,6 @@
 <script>
 import { _VIEW } from '@shell/config/query-params';
+import { saferDump } from '@shell/utils/create-yaml';
 
 import Values from './Values.vue';
 
@@ -25,6 +26,8 @@ export default {
       questions: null
     };
 
+    this.yamlValues = saferDump(this.value);
+
     let questionsJson = null;
 
     if ( this.value.spec?.settings ) {
@@ -35,11 +38,14 @@ export default {
   },
 
   data() {
-    return { chartValues: null };
+    return {
+      chartValues: null,
+      yamlValues:  ''
+    };
   }
 };
 </script>
 
 <template>
-  <Values :value="value" :chart-values="chartValues" :mode="mode" />
+  <Values :value="value" :chart-values="chartValues" :yaml-values="yamlValues" :mode="mode" />
 </template>

--- a/pkg/kubewarden/components/policies/Create.vue
+++ b/pkg/kubewarden/components/policies/Create.vue
@@ -18,7 +18,9 @@ import ChartReadme from '@shell/components/ChartReadme';
 import Wizard from '@shell/components/Wizard';
 
 import { NAMESPACE_SELECTOR } from '../../plugins/kubewarden/policy-class';
-import { KUBEWARDEN, KUBEWARDEN_PRODUCT_NAME } from '../../types';
+import { KUBEWARDEN, KUBEWARDEN_PRODUCT_NAME, VALUES_STATE } from '../../types';
+
+import defaultPolicy from '../../questions/policies/defaultPolicy.json';
 
 import PolicyGrid from './PolicyGrid';
 import Values from './Values';
@@ -70,9 +72,11 @@ export default ({
       }
     }
 
-    this.defaultPolicy = require(`../../questions/policies/defaultPolicy.json`);
-
-    this.yamlValues = saferDump(this.defaultPolicy);
+    if ( this.chartValues?.policy ) {
+      this.yamlValues = saferDump(this.chartValues.policy);
+    } else {
+      this.yamlValues = saferDump(defaultPolicy);
+    }
 
     this.value.apiVersion = `${ this.schema?.attributes?.group }.${ this.schema?.attributes?.version }`;
     this.value.kind = this.schema?.attributes?.kind;
@@ -90,10 +94,11 @@ export default ({
       version:           null,
 
       chartValues:       null,
-      yamlValues:        null,
-      defaultPolicy:     null,
+      yamlValues:        '',
+      // defaultPolicy:     '',
 
       hasCustomPolicy: false,
+      yamlOption:      VALUES_STATE.FORM,
 
       // Steps
       stepPolicies: {
@@ -119,14 +124,6 @@ export default ({
     };
   },
 
-  watch: {
-    hasCustomPolicy(neu, old) {
-      if ( !old ) {
-        this.policyQuestions(neu);
-      }
-    }
-  },
-
   computed: {
     isCreate() {
       return this.realMode === _CREATE;
@@ -141,6 +138,10 @@ export default ({
     },
 
     canFinish() {
+      if ( this.yamlOption === VALUES_STATE.YAML ) {
+        return true;
+      }
+
       return !!this.chartValues.policy.spec.module && this.hasRequiredRules;
     },
 
@@ -240,6 +241,7 @@ export default ({
 
     async finish(event) {
       try {
+        let out;
         const { ignoreRancherNamespaces } = this.chartValues.policy;
 
         if ( ignoreRancherNamespaces ) {
@@ -247,7 +249,11 @@ export default ({
           delete this.chartValues.policy.ignoreRancherNamespaces;
         }
 
-        const out = this.chartValues?.policy ? this.chartValues.policy : jsyaml.load(this.yamlValues);
+        if ( this.yamlOption === VALUES_STATE.YAML ) {
+          out = jsyaml.load(this.yamlValues);
+        } else {
+          out = this.chartValues?.policy ? this.chartValues.policy : jsyaml.load(this.yamlValues);
+        }
 
         merge(this.value, out);
 
@@ -277,15 +283,18 @@ export default ({
       } catch (e) {}
     },
 
-    policyQuestions(isCustom) {
-      const shortType = !!isCustom ? 'defaultPolicy' : this.type?.replace(`${ KUBEWARDEN.SPOOFED.POLICIES }.`, '');
+    policyQuestions() {
+      const shortType = this.type?.replace(`${ KUBEWARDEN.SPOOFED.POLICIES }.`, '');
       let match, questionsMatch;
 
       try {
-        match = require(`../../questions/policies/${ shortType }.json`);
+        if ( shortType !== 'custom' ) {
+          match = require(`../../questions/policies/${ shortType }.json`);
+        }
+
+        match = defaultPolicy;
       } catch (e) {
         console.warn('Unable to match policy chart, falling back to default'); // eslint-disable-line no-console
-        match = this.defaultPolicy;
       }
 
       set(this.chartValues, 'policy', match);
@@ -314,8 +323,7 @@ export default ({
             'typeModule',
             'version',
             'chartValues.policy',
-            'yamlValues',
-            'hasCustomPolicy'
+            'hasCustomPolicy',
           ];
 
           initialState.forEach((i) => {
@@ -324,6 +332,8 @@ export default ({
 
           this.stepPolicies.ready = false;
           this.stepReadme.hidden = false;
+          this.yamlOption = VALUES_STATE.FORM;
+          this.yamlValues = '';
         }
       });
     },
@@ -417,7 +427,14 @@ export default ({
       </template>
 
       <template #values>
-        <Values :value="value" :chart-values="chartValues" :mode="mode" :custom-policy="customPolicy" />
+        <Values
+          :value="value"
+          :chart-values="chartValues"
+          :yaml-values="yamlValues"
+          :mode="mode"
+          :custom-policy="customPolicy"
+          @editor="$event => yamlOption = $event"
+        />
       </template>
 
       <template #finish>

--- a/pkg/kubewarden/components/policies/Create.vue
+++ b/pkg/kubewarden/components/policies/Create.vue
@@ -290,9 +290,9 @@ export default ({
       try {
         if ( shortType !== 'custom' ) {
           match = require(`../../questions/policies/${ shortType }.json`);
+        } else {
+          match = defaultPolicy;
         }
-
-        match = defaultPolicy;
       } catch (e) {
         console.warn('Unable to match policy chart, falling back to default'); // eslint-disable-line no-console
       }

--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -21,8 +21,7 @@ export const RELATED_POLICY_SUMMARY = {
   value:     'allRelatedPolicies.length',
   sort:      false,
   search:    false,
-  formatter: 'PolicySummaryGraph',
-  align:     'center',
+  formatter: 'PolicySummaryGraph'
 };
 
 export function init($plugin, store) {

--- a/pkg/kubewarden/detail/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.admissionpolicy.vue
@@ -1,6 +1,5 @@
 <script>
 import { mapGetters } from 'vuex';
-import flatMap from 'lodash/flatMap';
 import isEmpty from 'lodash/isEmpty';
 
 import {
@@ -90,21 +89,20 @@ export default {
     }
 
     this.jaegerService = await this.value.jaegerService();
-    this.traces = await this.value.jaegerProxy() || [];
 
-    if ( this.traces.length > 1 ) {
-      this.traces = flatMap(this.traces);
+    if ( this.jaegerService ) {
+      this.filteredValidations = await this.value.jaegerSpecificValidations({ service: this.jaegerService });
     }
   },
 
   data() {
     return {
-      jaegerService:   null,
-      metricsProxy:    null,
-      metricsService:  null,
-      monitoringRoute: null,
-      reloadRequired:  false,
-      traces:          null,
+      jaegerService:       null,
+      metricsProxy:        null,
+      metricsService:      null,
+      monitoringRoute:     null,
+      reloadRequired:      false,
+      filteredValidations: null,
 
       metricsType: METRICS_DASHBOARD.POLICY
     };
@@ -121,11 +119,11 @@ export default {
     },
 
     emptyTraces() {
-      if ( this.traces ) {
-        return !this.traces.find(t => t.data.length);
+      if ( isEmpty(this.filteredValidations) ) {
+        return true;
       }
 
-      return true;
+      return false;
     },
 
     hasRelationships() {
@@ -141,7 +139,11 @@ export default {
     },
 
     tracesRows() {
-      return this.value.traceTableRows(this.traces);
+      if ( this.filteredValidations ) {
+        return this.value.traceTableRows(this.filteredValidations);
+      }
+
+      return [];
     }
   },
 

--- a/pkg/kubewarden/detail/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -90,21 +90,20 @@ export default {
     }
 
     this.jaegerService = await this.value.jaegerService();
-    this.traces = await this.value.jaegerProxy() || [];
 
-    if ( this.traces.length > 1 ) {
-      this.traces = flatMap(this.traces);
+    if ( this.jaegerService ) {
+      this.filteredValidations = await this.value.jaegerSpecificValidations({ service: this.jaegerService });
     }
   },
 
   data() {
     return {
-      jaegerService:   null,
-      metricsProxy:    null,
-      metricsService:  null,
-      monitoringRoute: null,
-      reloadRequired:  false,
-      traces:          null,
+      jaegerService:       null,
+      metricsProxy:        null,
+      metricsService:      null,
+      monitoringRoute:     null,
+      reloadRequired:      false,
+      filteredValidations: null,
 
       metricsType: METRICS_DASHBOARD.POLICY
     };
@@ -119,11 +118,11 @@ export default {
     },
 
     emptyTraces() {
-      if ( this.traces ) {
-        return !this.traces.find(t => t.data.length);
+      if ( isEmpty(this.filteredValidations) ) {
+        return true;
       }
 
-      return true;
+      return false;
     },
 
     hasRelationships() {
@@ -139,7 +138,11 @@ export default {
     },
 
     tracesRows() {
-      return this.value.traceTableRows(this.traces);
+      if ( this.filteredValidations ) {
+        return this.value.traceTableRows(this.filteredValidations);
+      }
+
+      return [];
     }
   },
 

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -67,7 +67,8 @@ kubewarden:
         The default PolicyServer and policies are not installed, click the button below to begin installing this chart. See the <a target="_blank" rel="noopener noreferrer nofollow" href="https://docs.kubewarden.io/quick-start#installation">documentation</a> for more information on installing charts.
       button: Install Chart
     policyGauge:
-      byState: Policies by State
+      byStatus: Policies by Status
+      traces: Policy Validations
   admissionPolicy:
     title: Admission Policies
     description: AdmissionPolicy is a namespace-wide resource. These policies will process only the requests that are targeting the Namespace where the AdmissionPolicy is defined.

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -66,6 +66,8 @@ kubewarden:
       description: |
         The default PolicyServer and policies are not installed, click the button below to begin installing this chart. See the <a target="_blank" rel="noopener noreferrer nofollow" href="https://docs.kubewarden.io/quick-start#installation">documentation</a> for more information on installing charts.
       button: Install Chart
+    policyGauge:
+      byState: Policies by State
   admissionPolicy:
     title: Admission Policies
     description: AdmissionPolicy is a namespace-wide resource. These policies will process only the requests that are targeting the Namespace where the AdmissionPolicy is defined.

--- a/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
@@ -84,6 +84,32 @@ export default class PolicyServer extends KubewardenModel {
     };
   }
 
+  get policyGauges() {
+    return async() => {
+      const out = {};
+      const relatedPolicies = await this.allRelatedPolicies();
+
+      if ( !relatedPolicies ) {
+        return out;
+      }
+
+      relatedPolicies?.map((policy) => {
+        const { colorForState, stateDisplay } = policy;
+
+        if ( out[stateDisplay] ) {
+          out[stateDisplay].count++;
+        } else {
+          out[stateDisplay] = {
+            color: colorForState.replace('text-', ''),
+            count: 1
+          };
+        }
+      });
+
+      return out;
+    };
+  }
+
   get jaegerProxies() {
     return async() => {
       const jaeger = await this.jaegerService();

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -40,3 +40,8 @@ export const METRICS_DASHBOARD = {
   POLICY_SERVER: 'kubewarden-dashboard-policyserver',
   POLICY:        'kubewarden-dashboard-policy'
 };
+
+export const VALUES_STATE = {
+  FORM: 'FORM',
+  YAML: 'YAML',
+};


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #168 

This adds insight cards with totals for policies by status and for tracing information.

![policycards](https://user-images.githubusercontent.com/40806497/206584198-032eac7b-a3e2-4b8f-8c8b-18ef72e61820.png)
