### PR TITLE
Update policy filtering and policy table headers

### DIFF
--- a/pkg/kubewarden/components/policies/Values.vue
+++ b/pkg/kubewarden/components/policies/Values.vue
@@ -9,18 +9,7 @@ import ResourceCancelModal from '@shell/components/ResourceCancelModal';
 import Tabbed from '@shell/components/Tabbed';
 import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 
-import { VALUES_STATE } from '../../types';
-
-const YAML_OPTIONS = [
-  {
-    labelKey: 'catalog.install.section.chartOptions',
-    value:    VALUES_STATE.FORM,
-  },
-  {
-    labelKey: 'catalog.install.section.valuesYaml',
-    value:    VALUES_STATE.YAML,
-  }
-];
+import { VALUES_STATE, YAML_OPTIONS } from '../../types';
 
 export default {
   name: 'Values',

--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -1,28 +1,13 @@
 import { STATE, NAME as NAME_HEADER } from '@shell/config/table-headers';
 import {
   KUBEWARDEN,
-  KUBEWARDEN_DASHBOARD
+  KUBEWARDEN_DASHBOARD,
+  ADMISSION_POLICY_STATE,
+  ADMISSION_POLICY_MODE,
+  ADMISSION_POLICY_RESOURCES,
+  ADMISSION_POLICY_OPERATIONS,
+  RELATED_POLICY_SUMMARY
 } from '../types';
-
-export const CHART_NAME = 'rancher-kubewarden';
-
-export const ADMISSION_POLICY_STATE = {
-  name:      'policyStatus',
-  sort:      ['stateSort', 'nameSort'],
-  value:     'status.policyStatus',
-  label:     'Status',
-  width:     100,
-  formatter: 'PolicyStatus',
-};
-
-export const RELATED_POLICY_SUMMARY = {
-  name:      'summary',
-  label:     'Policies',
-  value:     'allRelatedPolicies.length',
-  sort:      false,
-  search:    false,
-  formatter: 'PolicySummaryGraph'
-};
 
 export function init($plugin, store) {
   const {
@@ -149,28 +134,14 @@ export function init($plugin, store) {
   headers(ADMISSION_POLICY, [
     ADMISSION_POLICY_STATE,
     NAME_HEADER,
+    ADMISSION_POLICY_MODE,
     {
       name:  'capPolicyServer',
       label: 'Policy Server',
       value: 'spec.policyServer'
     },
-    {
-      name:  'mode',
-      label: 'Mode',
-      value: 'spec.mode'
-    },
-    {
-      name:          'kubewardenAdmissionPolicies',
-      label:         'Module',
-      value:         'spec.module',
-      formatterOpts: {
-        options: { internal: true },
-        to:      {
-          name:   'c-cluster-product-resource-id',
-          params: { resource: ADMISSION_POLICY }
-        }
-      },
-    },
+    ADMISSION_POLICY_RESOURCES,
+    ADMISSION_POLICY_OPERATIONS,
     {
       name:      'capCreated',
       label:     'Created',
@@ -182,28 +153,14 @@ export function init($plugin, store) {
   headers(CLUSTER_ADMISSION_POLICY, [
     ADMISSION_POLICY_STATE,
     NAME_HEADER,
+    ADMISSION_POLICY_MODE,
     {
       name:  'capPolicyServer',
       label: 'Policy Server',
       value: 'spec.policyServer'
     },
-    {
-      name:  'mode',
-      label: 'Mode',
-      value: 'spec.mode'
-    },
-    {
-      name:          'kubewardenClusterAdmissionPolicies',
-      label:         'Module',
-      value:         'spec.module',
-      formatterOpts: {
-        options: { internal: true },
-        to:      {
-          name:   'c-cluster-product-resource-id',
-          params: { resource: CLUSTER_ADMISSION_POLICY }
-        }
-      },
-    },
+    ADMISSION_POLICY_RESOURCES,
+    ADMISSION_POLICY_OPERATIONS,
     {
       name:      'capCreated',
       label:     'Created',

--- a/pkg/kubewarden/detail/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -1,6 +1,5 @@
 <script>
 import { mapGetters } from 'vuex';
-import flatMap from 'lodash/flatMap';
 import isEmpty from 'lodash/isEmpty';
 
 import {

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -16,8 +16,7 @@ import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
 
 import { isEmpty } from 'lodash';
-import { METRICS_DASHBOARD } from '../types';
-import { RELATED_HEADERS } from '../models/policies.kubewarden.io.policyserver';
+import { METRICS_DASHBOARD, RELATED_HEADERS } from '../types';
 
 import MetricsBanner from '../components/MetricsBanner';
 import TraceTable from '../components/TraceTable';

--- a/pkg/kubewarden/formatters/PolicyMode.vue
+++ b/pkg/kubewarden/formatters/PolicyMode.vue
@@ -1,0 +1,40 @@
+<script>
+import { BadgeState } from '@components/BadgeState';
+
+import { MODE_MAP } from '../plugins/kubewarden/policy-class';
+
+export default {
+  components: { BadgeState },
+
+  props:      {
+    value: {
+      type:     String,
+      default: ''
+    }
+  },
+
+  data() {
+    return { MODE_MAP };
+  },
+
+  computed: {
+    capitalizedMode() {
+      return this.value?.charAt(0).toUpperCase() + this.value?.slice(1);
+    },
+
+    modeColor() {
+      return this.MODE_MAP[this.value];
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <BadgeState
+      v-if="value"
+      :color="modeColor"
+      :label="capitalizedMode"
+    />
+  </div>
+</template>

--- a/pkg/kubewarden/formatters/PolicyResources.vue
+++ b/pkg/kubewarden/formatters/PolicyResources.vue
@@ -1,0 +1,70 @@
+<script>
+import isEmpty from 'lodash/isEmpty';
+
+export default {
+  props:      {
+    col: {
+      type:    Object,
+      default: () => {}
+    },
+    value: {
+      type:     Array,
+      default:  () => {
+        return [];
+      }
+    }
+  },
+
+  fetch() {
+    if ( this.value ) {
+      const resourceToShow = this.value.flatMap(r => r[this.col.name]);
+
+      if ( resourceToShow ) {
+        this.resourceToShow = [...new Set(resourceToShow)];
+      }
+    }
+  },
+
+  data() {
+    return { resourceToShow: null };
+  },
+
+  computed: {
+    mainResource() {
+      if ( !isEmpty(this.resourceToShow) ) {
+        return this.resourceToShow[0];
+      }
+
+      return '-';
+    },
+
+    resourceLabels() {
+      if ( this.resourceToShow.length > 1 ) {
+        let out = '';
+
+        this.resourceToShow.forEach((resource) => {
+          out += `&#8226; ${ resource }<br>`;
+        });
+
+        return out;
+      }
+
+      return null;
+    },
+  }
+};
+</script>
+
+<template>
+  <div>
+    <span>{{ mainResource }}</span>
+    <br>
+    <span
+      v-if="resourceToShow.length - 1 > 0"
+      v-tooltip.bottom="resourceLabels"
+      class="plus-more"
+    >
+      {{ t('generic.plusMore', { n: resourceToShow.length - 1 }) }}
+    </span>
+  </div>
+</template>

--- a/pkg/kubewarden/formatters/PolicyStatus.vue
+++ b/pkg/kubewarden/formatters/PolicyStatus.vue
@@ -31,6 +31,12 @@ export default {
 
       immediate: true
     }
+  },
+
+  methods: {
+    capitalizeMessage(m) {
+      return m?.charAt(0).toUpperCase() + m?.slice(1);
+    },
   }
 };
 </script>
@@ -40,7 +46,7 @@ export default {
     <BadgeState
       v-if="value"
       :color="stateBackground"
-      :label="stateDisplay"
+      :label="capitalizeMessage(stateDisplay)"
     />
   </div>
 </template>

--- a/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
@@ -3,52 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import { POD, WORKLOAD_TYPES } from '@shell/config/types';
 
 import KubewardenModel, { colorForTraceStatus } from '../plugins/kubewarden/policy-class';
-import { ADMISSION_POLICY_STATE } from '../config/kubewarden';
 import { KUBEWARDEN } from '../types';
-
-export const RELATED_HEADERS = [
-  ADMISSION_POLICY_STATE,
-  {
-    name:   'name',
-    value:  'metadata.name',
-    label:  'Name',
-    sort:   'name:desc'
-  },
-  {
-    name:   'module',
-    value:  'spec.module',
-    label:  'Module',
-    sort:   'module'
-  },
-  {
-    name:   'mode',
-    value:  'spec.mode',
-    label:  'Mode',
-    sort:   'mode'
-  },
-  {
-    name:      'psCreated',
-    label:     'Created',
-    value:     'metadata.creationTimestamp',
-    formatter: 'LiveDate'
-  }
-];
-
-export const VALUES_STATE = {
-  FORM: 'FORM',
-  YAML: 'YAML',
-};
-
-export const YAML_OPTIONS = [
-  {
-    labelKey: 'catalog.install.section.chartOptions',
-    value:    VALUES_STATE.FORM,
-  },
-  {
-    labelKey: 'catalog.install.section.valuesYaml',
-    value:    VALUES_STATE.YAML,
-  }
-];
 
 export default class PolicyServer extends KubewardenModel {
   get _availableActions() {

--- a/pkg/kubewarden/plugins/kubewarden/policy-class.js
+++ b/pkg/kubewarden/plugins/kubewarden/policy-class.js
@@ -333,7 +333,7 @@ export default class KubewardenModel extends SteveModel {
         let out = await Promise.all(promises);
 
         if ( out.length > 1 ) {
-          out = [...new Set(out.flatMap(o => o.data))];
+          out = out.flatMap(o => o.data);
         }
 
         return out;
@@ -496,7 +496,7 @@ export default class KubewardenModel extends SteveModel {
       return null;
     });
 
-    return [...new Set(out)];
+    return out;
   }
 
   updateWhitelist(url, remove) {

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -1,6 +1,8 @@
 export const KUBEWARDEN_PRODUCT_NAME = 'kubewarden';
 export const KUBEWARDEN_PRODUCT_GROUP = 'policies.kubewarden.io';
 
+export const CHART_NAME = 'rancher-kubewarden';
+
 export const KUBEWARDEN_DASHBOARD = 'dashboard';
 
 export const KUBEWARDEN = {
@@ -45,3 +47,72 @@ export const VALUES_STATE = {
   FORM: 'FORM',
   YAML: 'YAML',
 };
+
+export const YAML_OPTIONS = [
+  {
+    labelKey: 'catalog.install.section.chartOptions',
+    value:    VALUES_STATE.FORM,
+  },
+  {
+    labelKey: 'catalog.install.section.valuesYaml',
+    value:    VALUES_STATE.YAML,
+  }
+];
+
+export const ADMISSION_POLICY_STATE = {
+  name:      'policyStatus',
+  sort:      ['stateSort', 'nameSort'],
+  value:     'status.policyStatus',
+  label:     'Status',
+  width:     100,
+  formatter: 'PolicyStatus',
+};
+
+export const ADMISSION_POLICY_MODE = {
+  name:      'mode',
+  label:     'Mode',
+  value:     'spec.mode',
+  formatter: 'PolicyMode'
+};
+
+export const ADMISSION_POLICY_RESOURCES = {
+  name:      'resources',
+  label:     'Resources',
+  value:     'spec.rules',
+  formatter: 'PolicyResources'
+};
+
+export const ADMISSION_POLICY_OPERATIONS = {
+  name:      'operations',
+  label:     'Operations',
+  value:     'spec.rules',
+  formatter: 'PolicyResources'
+};
+
+export const RELATED_POLICY_SUMMARY = {
+  name:      'summary',
+  label:     'Policies',
+  value:     'allRelatedPolicies.length',
+  sort:      false,
+  search:    false,
+  formatter: 'PolicySummaryGraph'
+};
+
+export const RELATED_HEADERS = [
+  ADMISSION_POLICY_STATE,
+  {
+    name:   'name',
+    value:  'metadata.name',
+    label:  'Name',
+    sort:   'name:desc'
+  },
+  ADMISSION_POLICY_MODE,
+  ADMISSION_POLICY_RESOURCES,
+  ADMISSION_POLICY_OPERATIONS,
+  {
+    name:      'psCreated',
+    label:     'Created',
+    value:     'metadata.creationTimestamp',
+    formatter: 'LiveDate'
+  }
+];


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #162 

This updates the filtering for all ClusterAdmissionPolicies and AdmissionPolicies on their respective list pages. Also updates the headers used for each policy which now includes:
- Resources
- Operations

I felt it made the most sense to update the filters to give the ability to search for multiple property values, this keeps the filtering consistent with the same flow as creating policies gives.

https://user-images.githubusercontent.com/40806497/206768567-d008cc26-f1d4-434b-a872-5ee9a8a89800.mp4
