### PR TITLE
Update traces table to flatlist - policy filter by mode

### DIFF
--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -79,7 +79,6 @@ export default {
       v-if="rows"
       :rows="rows"
       :headers="TRACE_HEADERS"
-      :group-by="groupField"
       :table-actions="false"
       :row-actions="false"
       key-field="traceID"

--- a/pkg/kubewarden/components/policies/PolicyList.vue
+++ b/pkg/kubewarden/components/policies/PolicyList.vue
@@ -25,9 +25,13 @@ export default {
 
   data() {
     return {
-      resources:        null,
-      operations:       null
+      mode:             null,
+      resources:        null
     };
+  },
+
+  created() {
+    this.mode = 'All';
   },
 
   computed: {
@@ -41,14 +45,10 @@ export default {
       const out = rows.filter((row) => {
         const flatRules = flattenDeep(row.spec.rules);
         const flatResources = flatRules.flatMap(r => r.resources);
-        const flatOperations = flatRules.flatMap(r => r.operations);
+        const rowMode = row.spec.mode;
 
-        if ( this.operations ) {
-          for ( const selected of this.operations ) {
-            if ( !flatOperations.includes(selected) ) {
-              return false;
-            }
-          }
+        if ( this.mode && this.mode !== 'All' && this.mode !== rowMode ) {
+          return false;
         }
 
         if ( this.resources ) {
@@ -65,12 +65,16 @@ export default {
       return sortBy(out, ['id']);
     },
 
-    resourceOptions() {
-      return this.flattenRule('resources');
+    modeOptions() {
+      const out = this.rows?.map(row => row.spec?.mode) || [];
+
+      out.unshift('All');
+
+      return [...new Set(out)];
     },
 
-    operationOptions() {
-      return this.flattenRule('operations');
+    resourceOptions() {
+      return this.flattenRule('resources');
     }
   },
 
@@ -91,7 +95,7 @@ export default {
 
     resetFilter() {
       this.$set(this, 'resources', null);
-      this.$set(this, 'operations', null);
+      this.$set(this, 'mode', 'All');
     }
   }
 };
@@ -106,18 +110,18 @@ export default {
         :taggable="true"
         :multiple="true"
         class="filter__resources"
-        label="Filter by Resource"
+        label="Search by Resource"
         :options="resourceOptions"
       />
       <LabeledSelect
-        v-model="operations"
+        v-model="mode"
         :clearable="true"
         :searchable="false"
-        :options="operationOptions"
-        :multiple="true"
+        :options="modeOptions"
+        :multiple="false"
         placement="bottom"
-        class="filter__operations"
-        label="Filter by Operations"
+        class="filter__mode"
+        label="Search by Mode"
       />
       <button
         ref="btn"

--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -1,4 +1,4 @@
-import { STATE, NAME as NAME_HEADER } from '@shell/config/table-headers';
+import { AGE, STATE, NAME as NAME_HEADER } from '@shell/config/table-headers';
 import {
   KUBEWARDEN,
   KUBEWARDEN_DASHBOARD,
@@ -123,12 +123,7 @@ export function init($plugin, store) {
       },
     },
     RELATED_POLICY_SUMMARY,
-    {
-      name:      'psAge',
-      label:     'Age',
-      value:     'metadata.creationTimestamp',
-      formatter: 'LiveDate'
-    }
+    AGE
   ]);
 
   headers(ADMISSION_POLICY, [
@@ -142,12 +137,7 @@ export function init($plugin, store) {
     },
     ADMISSION_POLICY_RESOURCES,
     ADMISSION_POLICY_OPERATIONS,
-    {
-      name:      'capCreated',
-      label:     'Created',
-      value:     'metadata.creationTimestamp',
-      formatter: 'LiveDate'
-    }
+    AGE
   ]);
 
   headers(CLUSTER_ADMISSION_POLICY, [
@@ -161,11 +151,6 @@ export function init($plugin, store) {
     },
     ADMISSION_POLICY_RESOURCES,
     ADMISSION_POLICY_OPERATIONS,
-    {
-      name:      'capCreated',
-      label:     'Created',
-      value:     'metadata.creationTimestamp',
-      formatter: 'LiveDate'
-    }
+    AGE
   ]);
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #174, Fix #178 

This changes the traces table in the policy server detail view to a flat list which will now show the most recent traces at the top. Also updated the policy filtering by replacing the Operations filter with a Mode filter.

___Traces flat list___
![flatlist](https://user-images.githubusercontent.com/40806497/207358935-0c1c86e0-95ae-49d3-a1ba-6e1739bd2aa3.png)

