### PR TITLE
Fix dashboard page refresh and hanging installation

### DIFF
--- a/pkg/kubewarden/config/kubewarden.js
+++ b/pkg/kubewarden/config/kubewarden.js
@@ -1,4 +1,5 @@
 import { AGE, STATE, NAME as NAME_HEADER } from '@shell/config/table-headers';
+
 import {
   KUBEWARDEN,
   KUBEWARDEN_DASHBOARD,
@@ -8,6 +9,7 @@ import {
   ADMISSION_POLICY_OPERATIONS,
   RELATED_POLICY_SUMMARY
 } from '../types';
+import { rootKubewardenRoute } from '../utils/custom-routing';
 
 export function init($plugin, store) {
   const {
@@ -40,7 +42,7 @@ export function init($plugin, store) {
     name:        KUBEWARDEN_DASHBOARD,
     namespaced:  false,
     weight:      99,
-    route:       { name: 'c-cluster-kubewarden' },
+    route:       rootKubewardenRoute(),
     overview:    true
   });
 

--- a/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
+++ b/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
@@ -165,10 +165,6 @@ export default {
       if ( !this.controllerChart ) {
         try {
           await this.getChartRoute();
-
-          if ( this.controllerChart ) {
-
-          }
         } catch (err) {
           this.errors = err;
 

--- a/pkg/kubewarden/routes/kubewarden-routes.ts
+++ b/pkg/kubewarden/routes/kubewarden-routes.ts
@@ -9,7 +9,7 @@ import ViewKubewardenNsResource from '../pages/c/_cluster/kubewarden/_resource/_
 const routes = [
   {
     name:       `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
-    path:       `/c/:cluster/:product`,
+    path:       `/c/:cluster/:product/dashboard`,
     component:  Dashboard,
   },
   {

--- a/pkg/kubewarden/utils/custom-routing.ts
+++ b/pkg/kubewarden/utils/custom-routing.ts
@@ -1,0 +1,7 @@
+import { KUBEWARDEN_PRODUCT_NAME } from '../types';
+
+export const rootKubewardenRoute = () => ({
+  name:    `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
+  params: { product: KUBEWARDEN_PRODUCT_NAME },
+  meta:   { pkg: KUBEWARDEN_PRODUCT_NAME }
+});


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #187, Fix #188 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This fixes the issue when refreshing the page before installing the `kubewarden-controller` would return the page to a default resource list view. This also fixes the issue with a hanging installation after adding the kubewarden repository. 

## Test
- Remove any installed kubewarden extension and kubewarden helm repositories
- Run the dashboard locally
- Attempt to install 

___Refreshing the dashboard page___

https://user-images.githubusercontent.com/40806497/207625674-30177537-60db-4683-ba18-0dcecaa4b7ae.mp4



___Adding the repository 1st attempt___

https://user-images.githubusercontent.com/40806497/207625715-d0c85df1-0193-45da-ac07-1b04a545274b.mp4


___Adding the repository 2nd attempt___

https://user-images.githubusercontent.com/40806497/207625789-0a04d3d9-fcb1-4e4c-8725-f736a936d426.mp4


