### PR TITLE
Add dialog for updating policy mode - scaffold for store

### DIFF
--- a/pkg/kubewarden/components/policies/PolicyList.vue
+++ b/pkg/kubewarden/components/policies/PolicyList.vue
@@ -133,20 +133,7 @@ export default {
       </button>
     </div>
 
-    <ResourceTable :schema="schema" :rows="filteredRows" :headers="headers">
-      <template #col:mode="{ row }">
-        <td>
-          <span class="policy__mode">
-            <span class="text-capitalize">{{ row.spec.mode }}</span>
-            <i
-              v-if="hasNamespaceSelector(row)"
-              v-tooltip.bottom="t('kubewarden.policies.namespaceWarning')"
-              class="icon icon-warning"
-            />
-          </span>
-        </td>
-      </template>
-    </ResourceTable>
+    <ResourceTable :schema="schema" :rows="filteredRows" :headers="headers" />
   </div>
 </template>
 

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -208,19 +208,6 @@ export default {
                 />
               </td>
             </template>
-
-            <template #col:mode="{ row }">
-              <td>
-                <span class="policy__mode">
-                  <span class="text-capitalize">{{ row.spec.mode }}</span>
-                  <i
-                    v-if="hasNamespaceSelector(row)"
-                    v-tooltip.bottom="t('kubewarden.policies.namespaceWarning')"
-                    class="icon icon-warning"
-                  />
-                </span>
-              </td>
-            </template>
           </ResourceTable>
         </template>
       </Tab>

--- a/pkg/kubewarden/dialog/UpdateModeDialog.vue
+++ b/pkg/kubewarden/dialog/UpdateModeDialog.vue
@@ -1,0 +1,114 @@
+<script>
+import AsyncButton from '@shell/components/AsyncButton';
+
+import { Banner } from '@components/Banner';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+
+export default {
+  props: {
+    resources: {
+      type:     [Array, Object],
+      required: true
+    }
+  },
+
+  components: {
+    AsyncButton, Banner, Checkbox
+  },
+
+  data() {
+    return {
+      errors:          [],
+      updateToProtect: false
+    };
+  },
+
+  computed: {
+    policy() {
+      return this.resources[0];
+    },
+
+    modeDisabled() {
+      return this.policy?.spec?.mode === 'protect';
+    },
+  },
+
+  methods: {
+    close() {
+      this.errors = [];
+
+      this.$emit('close');
+    },
+
+    async updateMode(btnCb) {
+      this.errors = [];
+
+      try {
+        this.$set(this.policy.spec, 'mode', 'protect');
+        await this.policy.save();
+
+        btnCb(true);
+        this.close();
+      } catch (err) {
+        this.errors.push(err);
+        btnCb(false);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div
+    class="p-10"
+    :show-highlight-border="false"
+  >
+    <h4
+      slot="title"
+      class="text-default-text mb-10"
+    >
+      {{ t('kubewarden.policyConfig.mode.update.title') }}
+    </h4>
+    <div
+      slot="body"
+      class="pl-10 pr-10 mb-20 dialog-body"
+    >
+      <p class="mb-20">
+        {{ t('kubewarden.policyConfig.mode.update.body') }}
+      </p>
+      <Checkbox
+        v-model="updateToProtect"
+        :disabled="modeDisabled"
+        :label="t('kubewarden.policyConfig.mode.update.checkbox')"
+      />
+      <Banner v-if="updateToProtect" color="warning" :label="t('kubewarden.policyConfig.mode.warning')" />
+      <Banner
+        v-for="(err, i) in errors"
+        :key="i"
+        color="error"
+        :label="err.message"
+      />
+    </div>
+    <div
+      slot="actions"
+      class="buttons mt-10"
+    >
+      <div class="right">
+        <button
+          class="btn role-secondary mr-10"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </button>
+        <AsyncButton mode="edit" :disabled="!updateToProtect" @click="updateMode" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -2,6 +2,7 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 
 import kubewardenRoutes from './routes/kubewarden-routes';
+import kubewardenStore from './store/kubewarden';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -13,6 +14,9 @@ export default function(plugin: IPlugin) {
 
   // Load product
   plugin.addProduct(require('./config/kubewarden'));
+
+  // Add Vuex store
+  plugin.addDashboardStore(kubewardenStore.config.namespace, kubewardenStore.specifics, kubewardenStore.config);
 
   // Routes
   plugin.addRoutes(kubewardenRoutes);

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -112,6 +112,10 @@ kubewarden:
       label: Mode
       tooltip: The monitor mode is a way to deploy policies to the cluster in a way that all requests that go through the policy will be accepted, as if the policy didn't exist. Defaults to 'Protect'.
       warning: Once the policy mode has been switched to Protect, you will not be able to revert this change.
+      update:
+        checkbox: Update to Protect Mode
+        title: Update Policy Mode
+        body: The monitor mode is a way to view the behavior of a policy without letting it make the final decision on requests that are validated by the policy.
     ignoreRancherNamespaces:
       label: Ignore Rancher Namespaces
       tooltip: Certain policies will break core services of Rancher, this will add a default list of namespaces to ignore.

--- a/pkg/kubewarden/models/policies.kubewarden.io.admissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.admissionpolicy.js
@@ -4,6 +4,21 @@ import { get } from '@shell/utils/object';
 import KubewardenModel, { colorForStatus } from '../plugins/kubewarden/policy-class';
 
 export default class AdmissionPolicy extends KubewardenModel {
+  get _availableActions() {
+    const out = super._availableActions;
+
+    const policyMode = {
+      action:  'toggleUpdateMode',
+      enabled: this.spec.mode === 'monitor',
+      icon:    'icon icon-fw icon-notifier',
+      label:   'Update Mode',
+    };
+
+    out.unshift(policyMode);
+
+    return out;
+  }
+
   get stateDisplay() {
     const status = get(this, 'status.policyStatus');
 

--- a/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
@@ -4,6 +4,21 @@ import { get } from '@shell/utils/object';
 import KubewardenModel, { colorForStatus } from '../plugins/kubewarden/policy-class';
 
 export default class ClusterAdmissionPolicy extends KubewardenModel {
+  get _availableActions() {
+    const out = super._availableActions;
+
+    const policyMode = {
+      action:  'toggleUpdateMode',
+      enabled: this.spec.mode === 'monitor',
+      icon:    'icon icon-fw icon-notifier',
+      label:   'Update Mode',
+    };
+
+    out.unshift(policyMode);
+
+    return out;
+  }
+
   get stateDisplay() {
     const status = get(this, 'status.policyStatus');
 

--- a/pkg/kubewarden/plugins/kubewarden/policy-class.js
+++ b/pkg/kubewarden/plugins/kubewarden/policy-class.js
@@ -84,7 +84,7 @@ export const RULE_HEADERS = [
 ];
 
 export const MODE_MAP = {
-  monitor: 'bg-success',
+  monitor: 'bg-info',
   protect: 'bg-warning'
 };
 
@@ -501,6 +501,13 @@ export default class KubewardenModel extends SteveModel {
     });
 
     return out;
+  }
+
+  toggleUpdateMode( resources = this ) {
+    this.$dispatch('cluster/promptModal', {
+      resources,
+      component: 'UpdateModeDialog'
+    }, { root: true });
   }
 
   updateWhitelist(url, remove) {

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -1,0 +1,26 @@
+import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
+
+import { KUBEWARDEN_PRODUCT_NAME } from '../../types';
+
+import getters from './getters';
+import mutations from './mutations';
+import actions from './actions';
+
+const kubewardenFactory = (): CoreStoreSpecifics => {
+  return {
+    state() {
+      return {};
+    },
+
+    getters:   { ...getters },
+    mutations: { ...mutations },
+    actions:   { ...actions },
+  };
+};
+
+const config: CoreStoreConfig = { namespace: KUBEWARDEN_PRODUCT_NAME };
+
+export default {
+  specifics: kubewardenFactory(),
+  config
+};

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #182 

This adds an item in the action-menu for policies to update their mode to `protect`, the action will only be available on policies that are currently in `monitor` mode.

https://user-images.githubusercontent.com/40806497/207696178-9029a20b-8cf1-4018-8303-c9c3748f74c1.mp4


