### PR TITLE
Fix name header for related policies

### DIFF
--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -101,10 +101,13 @@ export const RELATED_POLICY_SUMMARY = {
 export const RELATED_HEADERS = [
   ADMISSION_POLICY_STATE,
   {
-    name:   'name',
-    value:  'metadata.name',
-    label:  'Name',
-    sort:   'name:desc'
+    name:          'name',
+    labelKey:      'tableHeaders.name',
+    value:         'metadata.name',
+    getValue:      (row: any) => row.metadata.name,
+    sort:          ['nameSort'],
+    formatter:     'LinkDetail',
+    canBeVariable: true,
   },
   ADMISSION_POLICY_MODE,
   ADMISSION_POLICY_RESOURCES,


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #173 

This will provide a clickable link to a policy when viewing the related policies within a Policy Server's detail view.

https://user-images.githubusercontent.com/40806497/207865108-ea385f2f-0c76-407b-8497-18a97c5d9de6.mp4


