### PR TITLE
Force update app catalog - disable install button condition

### DIFF
--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -148,7 +148,7 @@ export default {
         return;
       }
 
-      await this.$store.dispatch('catalog/load');
+      await this.$store.dispatch('catalog/load', { force: true });
 
       // Check to see that the chart we need are available
       const charts = this.$store.getters['catalog/rawCharts'];
@@ -249,6 +249,7 @@ export default {
           </p>
           <button
             class="btn role-primary mt-20"
+            :disabled="!installReady"
             @click.prevent="chartRoute"
           >
             {{ t("kubewarden.dashboard.appInstall.button") }}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #198 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
The issue stems from the catalog not being updated promptly when the Kubewarden repository is added, thus there is no chart for the installation target.
This forces the app catalog to update once the repository is added and disables the "Install Kubewarden" button in the final step of the installation wizard when the chart is not found.
