### PR TITLE
Add defaultsBanner to dashboard view and store

### DIFF
--- a/pkg/kubewarden/components/Dashboard/Card.vue
+++ b/pkg/kubewarden/components/Dashboard/Card.vue
@@ -55,6 +55,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  height: 100%;
   padding: $space-m;
   grid-auto-rows: 1fr;
   gap: $space-m;

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -1,0 +1,57 @@
+<script>
+import { isEmpty } from 'lodash';
+
+import { Banner } from '@components/Banner';
+
+export default {
+  components: { Banner },
+
+  methods: {
+    async closeDefaultsBanner(retry = 0) {
+      const res = await this.$store.dispatch('kubewarden/updateHideDefaultsBanner', true);
+
+      if ( retry === 0 && res?.type === 'error' && res?.status === 500 ) {
+        await this.closeDefaultsBanner(retry + 1);
+      }
+    },
+
+    async setChartRoute(retry = 0) {
+      // Check to see that `kubewarden-defaults` chart is available
+      const charts = this.$store.getters['catalog/rawCharts'];
+
+      if ( isEmpty(charts) && retry === 0 ) {
+        await this.$store.dispatch('catalog/load');
+
+        await this.setChartRoute(retry + 1);
+      }
+
+      const chartValues = Object.values(charts);
+
+      const controllerChart = chartValues.find(
+        chart => chart.chartName === 'kubewarden-defaults'
+      );
+
+      if ( controllerChart ) {
+        return controllerChart.goToInstall('kubewarden-defaults');
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Banner
+    class="mb-20 mt-0"
+    color="info"
+    :closable="true"
+    @close="closeDefaultsBanner()"
+  >
+    <p v-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)"></p>
+    <button
+      class="btn role-primary mt-10"
+      @click.prevent="setChartRoute"
+    >
+      {{ t("kubewarden.policyServer.noDefaultsInstalled.button") }}
+    </button>
+  </Banner>
+</template>

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,1 +1,5 @@
-export default {};
+export default {
+  updateHideDefaultsBanner({ commit }: any, val: Boolean) {
+    commit('updateHideDefaultsBanner', val);
+  }
+};

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,1 +1,1 @@
-export default {};
+export default { hideDefaultsBanner: (state: any) => state.hideDefaultsBanner };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -9,7 +9,7 @@ import actions from './actions';
 const kubewardenFactory = (): CoreStoreSpecifics => {
   return {
     state() {
-      return {};
+      return { hideDefaultsBanner: false };
     },
 
     getters:   { ...getters },

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,1 +1,5 @@
-export default {};
+export default {
+  updateHideDefaultsBanner(state: any, val: Boolean) {
+    state.hideDefaultsBanner = val;
+  }
+};


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #200 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
- Added the banner for installing the `kubewarden-defaults` chart to the Dashboard view for Kubewarden
- Fixed issue with persisting the state of the banner to remain closed
- Resized the dashboard cards to keep a consistent height for each

## Test

To test install the Kubewarden extension and stack, then navigate to the Dashboard view and click on the "Install Chart" button to install the defaults.
  
![banner](https://user-images.githubusercontent.com/40806497/212181558-7d4f1f3c-3947-40ca-aeb8-d9b7852ee924.png)


