### PR TITLE
Fix chart refresh on installation view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "engines": {
     "node": ">=12"

--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -139,7 +139,7 @@ export default {
       }
     },
 
-    async getChartRoute() {
+    async getChartRoute(retry = 0) {
       const allRepos = await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: CATALOG.CLUSTER_REPO });
 
       this.kubewardenRepo = allRepos?.find(r => r.spec.url === KUBEWARDEN_REPO);
@@ -157,6 +157,10 @@ export default {
       this.controllerChart = chartValues.find(
         chart => chart.chartName === 'kubewarden-controller'
       );
+
+      if ( !this.controllerChart && retry === 0 ) {
+        await this.getChartRoute(retry + 1);
+      }
     },
 
     async chartRoute() {

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "rancher": true,
   "scripts": {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This should solve the issue in #201 (will need to push new build to verify)

- Modified `getChartRoute` method to use `catalog/refresh` action and added a retry
- Restructured `controllerChart`  and `kubewardenRepo` to computed properties
- Fixed issue when detecting previously added Kubewarden repository
- Bump version `0.1.16`

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->


https://user-images.githubusercontent.com/40806497/212994814-4c4256e8-5e3a-4a88-b4db-ea5a167ccac1.mp4
