### PR TITLE
Fix dashboard defaults banner and policy server deployments card

### DIFF
--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -6,7 +6,7 @@ import { CATALOG, SERVICE } from '@shell/config/types';
 import AsyncButton from '@shell/components/AsyncButton';
 import CopyCode from '@shell/components/CopyCode';
 
-import { KUBEWARDEN_CHART, KUBEWARDEN_REPO } from '../../types';
+import { KUBEWARDEN_CHARTS, KUBEWARDEN_REPO } from '../../types';
 
 import InstallWizard from './InstallWizard';
 
@@ -80,7 +80,7 @@ export default {
     },
 
     controllerChart() {
-      return this.$store.getters['catalog/chart']({ chartName: KUBEWARDEN_CHART });
+      return this.$store.getters['catalog/chart']({ chartName: KUBEWARDEN_CHARTS.CONTROLLER });
     },
 
     kubewardenRepo() {

--- a/pkg/kubewarden/components/Policies/Values.vue
+++ b/pkg/kubewarden/components/Policies/Values.vue
@@ -9,7 +9,7 @@ import ResourceCancelModal from '@shell/components/ResourceCancelModal';
 import Tabbed from '@shell/components/Tabbed';
 import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 
-import { VALUES_STATE, YAML_OPTIONS } from '../../types';
+import { KUBEWARDEN_CHARTS, VALUES_STATE, YAML_OPTIONS } from '../../types';
 
 export default {
   name: 'Values',
@@ -56,7 +56,7 @@ export default {
       this.version = this.$store.getters['catalog/version']({
         repoType:      'cluster',
         repoName:      'kubewarden',
-        chartName:     'kubewarden-controller',
+        chartName:     KUBEWARDEN_CHARTS.CONTROLLER,
       });
 
       await this.loadValuesComponent();

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -7,6 +7,8 @@ import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations
 import Loading from '@shell/components/Loading';
 import ResourceTable from '@shell/components/ResourceTable';
 
+import { KUBEWARDEN_APPS } from '../types';
+
 import DefaultsBanner from '../components/DefaultsBanner';
 
 export default {
@@ -27,15 +29,17 @@ export default {
 
   async fetch() {
     await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: this.resource });
-
     await this.$store.dispatch('catalog/load');
 
-    // Determine if the default PolicyServer is installed from the `kubewarden-defaults` chart
+    /*
+      Determine if the default PolicyServer is installed from the `kubewarden-defaults` chart
+      When installed the App name will be `rancher-kubewarden-defaults`
+    */
     if ( !this.hideDefaultsBanner ) {
       const apps = await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: CATALOG.APP });
 
       this.hasDefaults = apps.find((a) => {
-        return a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === 'rancher-kubewarden-defaults';
+        return a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === KUBEWARDEN_APPS.RANCHER_DEFAULTS;
       });
     }
   },

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -5,7 +5,16 @@ export const CHART_NAME = 'rancher-kubewarden';
 
 export const KUBEWARDEN_DASHBOARD = 'dashboard';
 export const KUBEWARDEN_REPO = 'https://charts.kubewarden.io';
-export const KUBEWARDEN_CHART = 'kubewarden-controller';
+
+export const KUBEWARDEN_CHARTS = {
+  CONTROLLER:       'kubewarden-controller',
+  DEFAULTS:         'kubewarden-defaults',
+};
+
+export const KUBEWARDEN_APPS = {
+  RANCHER_CONTROLLER: 'rancher-kubewarden-controller',
+  RANCHER_DEFAULTS:   'rancher-kubewarden-defaults'
+};
 
 export const KUBEWARDEN = {
   ADMISSION_POLICY:         'policies.kubewarden.io.admissionpolicy',


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #208 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
The issue was caused by having the `hasDefaults` condition only being updated when initially fetched, converting this to a computed method fixes this. 
Also fixed the displaying of Policy Server gauges when no policy server is found.  

___Before installation___
![dashboard](https://user-images.githubusercontent.com/40806497/213485570-b0af2e4e-efe3-436a-87cb-e48f4fb2df69.png)

___After installation - still pending___
![dashboard-installed-1](https://user-images.githubusercontent.com/40806497/213485617-18d75554-f160-416c-a5b2-244ebc02bc11.png)

