### PR TITLE
Filter policies with rancher/hide-ui annotation

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -235,7 +235,9 @@ export default ({
         const promises = this.repository.packages.map(pkg => this.packageDetails(pkg));
 
         try {
-          this.packages = await Promise.all(promises);
+          const packages = await Promise.all(promises);
+
+          this.packages = packages.filter(pkg => pkg?.data?.['rancher/hide-ui'] !== 'true');
         } catch (e) {
           console.warn(`Error fetching packages: ${ e }`); // eslint-disable-line no-console
         }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #210 

This will filter out any policies from ArtifactHub which contain the annotation `rancher/hide-ui: true` from the Policy selection screen.

