### PR TITLE
Fix artifacthub whitelist loading packages, v1 tidy up

### DIFF
--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -60,9 +60,9 @@ export default {
     :closable="true"
     @close="closeDefaultsBanner()"
   >
-    <p v-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)"></p>
+    <span v-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)" />
     <button
-      class="btn role-primary mt-10"
+      class="btn role-primary ml-10"
       @click.prevent="chartRoute"
     >
       {{ t("kubewarden.policyServer.noDefaultsInstalled.button") }}

--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -16,10 +16,6 @@ export default {
       type:     String,
       required: true
     },
-    monitoringRoute: {
-      type:     Object,
-      default:  null
-    },
     reloadRequired: {
       type:     Boolean,
       default:  false
@@ -28,13 +24,23 @@ export default {
 
   components: { AsyncButton, Banner },
 
-  computed: { ...monitoringStatus() },
+  computed: {
+    ...monitoringStatus(),
+
+    monitoringChart() {
+      return this.$store.getters['catalog/chart']({ chartName: 'rancher-monitoring' });
+    },
+  },
 
   methods: {
     // Used when ConfigMap is added, reload to see updated Grafana dashboard
     reload() {
       this.$router.go();
     },
+
+    chartRoute() {
+      this.monitoringChart.goToInstall();
+    }
   }
 };
 </script>
@@ -43,9 +49,12 @@ export default {
   <div v-if="!monitoringStatus.installed">
     <Banner color="warning">
       <span v-html="t('kubewarden.monitoring.notInstalled', {}, true)" />
-      <nuxt-link :to="monitoringRoute">
-        {{ t('kubewarden.monitoring.install') }}
-      </nuxt-link>
+      <button
+        class="btn role-primary ml-10"
+        @click.prevent="chartRoute"
+      >
+        {{ t("kubewarden.policyServer.noDefaultsInstalled.button") }}
+      </button>
     </Banner>
   </div>
 

--- a/pkg/kubewarden/components/Policies/PolicyDetail.vue
+++ b/pkg/kubewarden/components/Policies/PolicyDetail.vue
@@ -59,33 +59,6 @@ export default {
       } catch (e) {
         console.error(`Error fetching Grafana service: ${ e }`); // eslint-disable-line no-console
       }
-    } else {
-      // If not we need to direct the user to install monitoring
-      await this.$store.dispatch('catalog/load');
-
-      // Check to see that the chart we need are available
-      const charts = this.$store.getters['catalog/rawCharts'];
-      const chartValues = Object.values(charts);
-
-      const monitoringChart = chartValues.find(
-        chart => chart.chartName === 'rancher-monitoring'
-      );
-
-      if ( monitoringChart ) {
-        this.monitoringRoute = {
-          name:   'c-cluster-apps-charts-install',
-          params: {
-            cluster:  this.$route.params.cluster,
-            product:  this.$store.getters['productId'],
-          },
-          query: {
-            [REPO_TYPE]: 'cluster',
-            [REPO]:      'rancher-charts',
-            [CHART]:     'rancher-monitoring',
-            [VERSION]:   monitoringChart.versions[0]?.version,
-          }
-        };
-      }
     }
 
     this.jaegerService = await this.value.jaegerService();
@@ -100,7 +73,6 @@ export default {
       jaegerService:       null,
       metricsProxy:        null,
       metricsService:      null,
-      monitoringRoute:     null,
       reloadRequired:      false,
       filteredValidations: null,
 
@@ -188,7 +160,6 @@ export default {
           v-if="!monitoringStatus.installed || !metricsService"
           :metrics-service="metricsService"
           :metrics-type="metricsType"
-          :monitoring-route="monitoringRoute"
           :reload-required="reloadRequired"
           @add="addDashboard"
         />

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -123,8 +123,6 @@ export default {
   <form
     class="create-resource-container step__policies"
   >
-    <slot name="whitelistBanner"></slot>
-
     <div class="filter">
       <LabeledSelect
         v-model="keywords"
@@ -181,15 +179,21 @@ export default {
           </div>
 
           <div v-if="subtype.signed" class="subtype__signed">
-            <i v-tooltip="t('kubewarden.policyCharts.signedPolicy')" class="icon icon-checkmark" />
+            <span v-tooltip="t('kubewarden.policyCharts.signedPolicy.tooltip')">
+              {{ t('kubewarden.policyCharts.signedPolicy.label') }}
+            </span>
           </div>
 
           <div v-if="subtype.data['kubewarden/mutation'] === 'true'" class="subtype__mutation">
-            <i v-tooltip="t('kubewarden.policyCharts.mutationPolicy')" class="icon icon-edit" />
+            <span v-tooltip="t('kubewarden.policyCharts.mutationPolicy.tooltip')">
+              {{ t('kubewarden.policyCharts.mutationPolicy.label') }}
+            </span>
           </div>
 
           <div v-if="subtype.data['kubewarden/contextAware'] === 'true'" class="subtype__aware">
-            <i v-tooltip="t('kubewarden.policyCharts.contextAware')" class="icon icon-show" />
+            <span>
+              {{ t('kubewarden.policyCharts.contextAware') }}
+            </span>
           </div>
 
           <h4 class="subtype__label">

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -90,21 +90,18 @@ export default {
       :paging="true"
       :rows-per-page="rowsPerPage"
     >
-      <template #col:operation="{row}">
-        <td>
-          <BadgeState
-            :label="row.operation"
-            :color="opColor(row.operation)"
-          />
-        </td>
-      </template>
-
       <template #col:mode="{row}">
         <td>
           <BadgeState
             :label="capitalizeMessage(row.mode)"
             :color="modeColor(row.mode)"
           />
+        </td>
+      </template>
+
+      <template #col:operation="{row}">
+        <td>
+          {{ row.operation }}
         </td>
       </template>
 

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -170,28 +170,28 @@ export const DASHBOARD_HEADERS = [
 
 export const TRACE_HEADERS = [
   {
-    name:  'operation',
-    value: 'operation',
-    label: 'Operation',
-    sort:  'operation'
-  },
-  {
     name:  'mode',
     value: 'mode',
     label: 'Mode',
     sort:  'mode'
   },
   {
-    name:  'kind',
-    value: 'kind',
-    label: 'Kind',
-    sort:  'kind'
-  },
-  {
     name:  'name',
     value: 'name',
     label: 'Name',
     sort:  'name'
+  },
+  {
+    name:  'operation',
+    value: 'operation',
+    label: 'Operation',
+    sort:  'operation'
+  },
+  {
+    name:  'kind',
+    value: 'kind',
+    label: 'Kind',
+    sort:  'kind'
   },
   {
     name:  'namespace',

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -107,7 +107,7 @@ kubewarden:
     title: Custom Policy
     description: A generic template for using your own policy.
   policies:
-    noArtifactHub: Official Kubewarden policies are hosted on ArtifactHub, in order to show these you will need to add `artifacthub.io` to the whitelist-domain setting.
+    noArtifactHub: Official Kubewarden policies are hosted on <a href="https://artifacthub.io/packages/search?kind=13" target="_blank" rel="noopener noreferrer nofollow">ArtifactHub</a>, in order to show these you will need to add `artifacthub.io` to the whitelist-domain setting.
     noRules: There are no rules configured for this policy.
     namespaceWarning: This policy is targeting Rancher specific namespaces which will cause catastrophic failures with your Rancher deployment.
   utils:
@@ -192,189 +192,13 @@ kubewarden:
       label: Verification Config
       description: This is the name of a VerificationConfig configmap within the same namespace, containing a Sigstore verification configuration. The configuration must be under a key named verification-config in the Configmap. More information can be found in the <a href="https://docs.kubewarden.io/distributing-policies/secure-supply-chain#configuring-the-policy-server-to-check-policy-signatures" target="_blank" rel="noopener noreferrer nofollow">Kubewarden docs</a>.
   policyCharts:
-    signedPolicy: This policy has been signed with cosign (Sigstore).
-    mutationPolicy: Mutation Policy
+    signedPolicy:
+      label: Signed
+      tooltip: This policy has been signed with cosign (Sigstore).
+    mutationPolicy:
+      label: Mutation
+      tooltip: Mutation Policy
     contextAware: Context Aware
-    allow-privilege-escalation-psp:
-      name: Allow Privilege Escalation PSP
-      description: A Pod Security Policy that controls usage of `allowPrivilegeEscalation`
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Privilege Escalation
-    allowed-fsgroups-psp:
-      name: Allowed fsGroups PSP
-      description: Replacement for the Kubernetes Pod Security Policy that controls the usage of fsGroup in the pod security context
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Runtime
-    allowed-proc-mount-types-psp:
-      name: Allowed Proc Mount Types PSP
-      description: Replacement for the Kubernetes Pod Security Policy that controls the usage of /proc mount types
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Runtime
-    apparmor-psp:
-      name: AppArmor PSP
-      description: A Pod Security Policy that controls usage of AppArmor profiles
-      resourceType: Pod
-      keywords: |
-        PSP
-        AppArmor
-    capabilities-psp:
-      name: Capabilities PSP
-      description: A Pod Security Policy that controls Container Capabilities
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Capability
-        Capabilities
-    disallow-service-loadbalancer:
-      name: Disallow Service LoadBalancer
-      description: A policy that prevents the creation of Service resources of type `LoadBalancer`
-      resourceType: Service
-      keywords: |
-        Service
-    disallow-service-nodeport:
-      name: Disallow Service NodePort
-      description: A policy that prevents the creation of Service resources of type `NodePort`
-      resourceType: Service
-      keywords: |
-        Service
-    flexvolume-drivers-psp:
-      name: FlexVolume Drivers PSP
-      description: Replacement for the Kubernetes Pod Security Policy that controls the allowed `flexVolume` drivers
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Runtime
-        Flex Volume
-        Flex
-    host-namespaces-psp:
-      name: Host Namespaces PSP
-      description: A Pod Security Policy that controls the usage of host namespaces
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Network
-    hostpaths-psp:
-      name: Hostpaths PSP
-      description: A Pod Security Policy that controls usage of hostPath volumes
-      resourceType: Pod
-      keywords: |
-        PSP
-        Hostpaths
-        Pod
-    ingress:
-      name: Ingress
-      description: Enforce requirements on Ingress resources
-      resourceType: Ingress
-      keywords: |
-        Ingress
-    pod-privileged-policy:
-      name: Pod Privileged Policy
-      description: Limit the ability to create privileged containers
-      resourceType: Pod
-      keywords: |
-        PSP
-        Pod
-        Container
-        Privileged
-    pod-runtime:
-      name: Pod Runtime
-      description: Control Pod runtimeClass usage
-      resourceType: Pod
-      keywords: |
-        Pod
-        Runtime
-        Container Runtime
-    readonly-root-filesystem-psp:
-      name: Readonly Root Filesystem PSP
-      description: A Kubewarden policy that enforces root filesystem to be readonly
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        filesystem
-        Volume
-    safe-annotations:
-      name: Safe Annotations
-      description: A policy that validates Kubernetes' resource annotations
-      resourceType: Global
-      keywords: |
-        Annotations
-    safe-labels:
-      name: Safe Labels
-      description: A policy that validates Kubernetes' resource labels
-      resourceType: Global
-      keywords: |
-        Labels
-    seccomp-psp:
-      name: Seccomp PSP
-      description: Pod Security Policy that controls usage of Seccomp profile
-      resourceType: Pod
-      keywords: |
-        PSP
-        seccomp
-    selinux-psp:
-      name: SELinux PSP
-      description: Replacement for the Kubernetes Pod Security Policy that controls the usage of SELinux
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        Runtime
-        SELinux
-    sysctl-psp:
-      name: Sysctl PSP
-      description: A Pod Security Policy that controls usage of sysctls in pods
-      resourceType: Pod
-      keywords: |
-        PSP
-        Sysctl
-        Pod
-    trusted-repos:
-      name: Trusted Repos
-      description: Restrict what registries, tags and images can be used
-      resourceType: Pod
-      keywords: |
-        Image
-        Registry
-        Tag
-    user-group-psp:
-      name: User Group PSP
-      description: A Pod Security Policy that controls the container user and groups
-      resourceType: Pod
-      keywords: |
-        PSP
-        Container
-        User
-        Group
-    verify-image-signatures:
-      name: Verify Image Signatures
-      description: Validates Sigstore signatures for containers, init container and ephemeral container that match the name provided in the image settings field.
-      resourceType: Pod
-      keywords: |
-        Pod
-        Signature
-        Sigstore
-        Trusted
-    volumes-psp:
-      name: Volumes PSP
-      description: Pod Security Policy that controls usage of volumes
-      resourceType: Pod
-      keywords: |
-        PSP
-        Volumes
-        Pod
 
 asyncButton:
   artifactHub:

--- a/pkg/kubewarden/plugins/policy-class.js
+++ b/pkg/kubewarden/plugins/policy-class.js
@@ -1,6 +1,6 @@
 import jsyaml from 'js-yaml';
 
-import { colorForState, stateDisplay } from '@shell/plugins/dashboard-store/resource-class';
+import { colorForState, stateBackground, stateDisplay } from '@shell/plugins/dashboard-store/resource-class';
 import { get } from '@shell/utils/object';
 
 import KubewardenModel, { ARTIFACTHUB_ENDPOINT, ARTIFACTHUB_PKG_ANNOTATION, colorForStatus } from './kubewarden-class';
@@ -61,6 +61,16 @@ export default class PolicyModel extends KubewardenModel {
     }
 
     return colorForState(this.state);
+  }
+
+  get stateBackground() {
+    const color = this.colorForState;
+
+    if ( color ) {
+      return color.replace('text-', 'bg-');
+    }
+
+    return stateBackground();
   }
 
   /*


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #219 


- When `artifacthub.io` is added to the whitelist, the packages are now refetched and a loading screen will be in place until the packages are fetched 
-  Removed line break from Default policies chart banner "Install Chart" button
- Replaced icons (signed, mutation, context aware) with text in policy cards listed on creation screen
- Fix color of policy state badge on policy detail page
- Changed "Install Monitoring" link to a button in monitoring tab
- Removed color from policy operation in traces
- Restructured layout of tracing columns to: Mode, Name, Operation, Kind, Namespace, Start Time, Duration
