### PR TITLE
Add Sequence type to questions components

### DIFF
--- a/pkg/kubewarden/components/Questions/SequenceMap.vue
+++ b/pkg/kubewarden/components/Questions/SequenceMap.vue
@@ -1,0 +1,153 @@
+<script>
+import { get } from '@shell/utils/object';
+
+import BooleanType from '@shell/components/Questions/Boolean';
+import EnumType from '@shell/components/Questions/Enum';
+import IntType from '@shell/components/Questions/Int';
+import FloatType from '@shell/components/Questions/Float';
+import ReferenceType from '@shell/components/Questions/Reference';
+import CloudCredentialType from '@shell/components/Questions/CloudCredential';
+
+/*
+  Replacing these components until we are able to hide inputs with `hide_input` property in questions
+*/
+import ArrayType from './Array';
+import MapType from './QuestionMap';
+import StringType from './String';
+import SequenceType from './SequenceMap';
+
+const knownTypes = {
+  string:          StringType,
+  hostname:        StringType, // @TODO
+  multiline:       StringType,
+  password:        StringType,
+  boolean:         BooleanType,
+  enum:            EnumType,
+  int:             IntType,
+  float:           FloatType,
+  questionMap:     MapType,
+  reference:       ReferenceType,
+  configmap:       ReferenceType,
+  secret:          ReferenceType,
+  storageclass:    ReferenceType,
+  pvc:             ReferenceType,
+  cloudcredential: CloudCredentialType,
+};
+
+function componentForQuestion(q) {
+  const type = (q.type || '').toLowerCase();
+
+  if ( knownTypes[type] ) {
+    return type;
+  } else if ( type.startsWith('array[') ) { // This only really works for array[string|multiline], but close enough for now.
+    return ArrayType;
+  } else if ( type.startsWith('map[') ) { // Same, only works with map[string|multiline]
+    return MapType;
+  } else if ( type.startsWith('reference[') ) { // Same, only works with map[string|multiline]
+    return ReferenceType;
+  } else if ( type.startsWith('sequence[') ) {
+    return SequenceType;
+  }
+
+  return 'string';
+}
+
+export default {
+  props: {
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    question: {
+      type:     Object,
+      required: true
+    },
+    value: {
+      type:    Array,
+      default: () => []
+    }
+  },
+
+  data() {
+    const seqQuestions = this.question.sequence_questions;
+
+    return { seqQuestions };
+  },
+
+  components: { ...knownTypes },
+
+  methods: {
+    componentForQuestion,
+    get,
+
+    update(variable, index, $event) {
+      const out = {
+        question: this.question, variable, index, $event
+      };
+
+      this.$emit('seqInput', out);
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <h3>
+      {{ question.label }}
+    </h3>
+    <div v-for="(val, vIndex) in value" :key="val + vIndex" class="seq__container mb-20">
+      <div
+        v-for="(q, index) in seqQuestions"
+        :key="index"
+        class="row question"
+      >
+        <div class="col span-12">
+          <component
+            :is="componentForQuestion(q)"
+            in-store="cluster"
+            :question="q"
+            :value="get(value[vIndex], q.variable)"
+            @input="update(q.variable, vIndex, $event)"
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        :disabled="disabled"
+        class="btn role-link remove btn-sm"
+        @click="$emit('removeSeq', { question, vIndex })"
+      >
+        {{ t('generic.remove') }}
+      </button>
+    </div>
+
+    <button
+      type="button"
+      class="btn role-tertiary add"
+      :disabled="disabled"
+      @click="$emit('addSeq', question)"
+    >
+      {{ t('generic.add') }}
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.seq {
+  &__container {
+    position: relative;
+    display: block;
+
+    & > .remove {
+      position: absolute;
+
+      padding: 0px;
+
+      top: 0;
+      right: 0;
+    }
+  }
+}
+</style>

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -114,7 +114,7 @@ kubewarden:
     resetFilter: Reset Filter
   tracing:
     noJaeger: |
-      No Jaeger service is installed, please follow the steps <a href="https://docs.kubewarden.io/operator-manual/telemetry/tracing/quickstart#install-jaeger" target="_blank" rel="noopener noreferrer nofollow">listed here</a> to setup tracing for your policies.
+      No Jaeger service is installed, please follow the steps <a href="https://docs.kubewarden.io/operator-manual/telemetry/tracing/quickstart" target="_blank" rel="noopener noreferrer nofollow">listed here</a> to setup tracing for your policies.
     noRelatedTraces: No tracing data exists for the related policies.
     noTraces: No tracing data exists for this policy. 
   monitoring:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #228 

This adds the Sequence type for consuming [`sequence`](https://yaml.org/type/seq.html) type in yaml.

In order for the Questions component to consume sequences of mappings, the `questions.yml` will now need to provide a separate property type for sequence: `sequence[`

An example for a question to be shown within `questions.yml`:

```yaml
questions:
- default: [] # the default should be an empty array
  tooltip: Valid user ID (UID) ranges for the fsGroup.
  group: Settings
  label: User ID Ranges
  type: sequence[ # this determines the question type
  variable: ranges
  sequence_questions: # this is required to show subsequent inputs
    - default: 1000
      tooltip: Minimum UID range for fsgroup.
      group: Settings
      label: min
      type: int
      variable: min # note the variable does not contain the parent property
    - default: 2000
      tooltip: Maximum UID range for fsgroup.
      group: Settings
      label: max
      type: int
      variable: max
```

This gives the user the ability to add and remove objects from the sequence.

> ***Note*** for testing purposes I spoofed a policy's questions.yml by adding them to the Custom Policy type. 

https://user-images.githubusercontent.com/40806497/217662136-e2ea4d3b-953a-494f-ae18-c50aadb93d24.mp4
