### PR TITLE
Initial UI tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,3 +16,4 @@ ksconfig.json
 nuxt.config.js
 shell/utils/dynamic-importer.js
 shell/assets/fonts
+tests/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+storageState.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,63 @@
+## Setup
+
+```bash
+# Download and setup
+git clone https://github.com/kubewarden/ui.git
+cd ui/tests/
+npm install
+npx playwright install
+
+# Optionally create an alias
+alias pw='npx playwright'
+```
+
+## Kubewarden Installation
+
+```bash
+# Requires RANCHER_URL variable:
+export RANCHER_URL=https://172.31.0.2.nip.io/
+pw test installation
+```
+
+## Howtos 
+
+### Set up tracing
+
+```bash
+# ==================================================================================================
+# Open Telemetry
+
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
+  --namespace open-telemetry --create-namespace
+
+# ==================================================================================================
+# Jaeger Tracing (can be installed from rancher)
+
+app=jaeger pw test helpers -g 'appInstall'
+kubectl patch apps.catalog.cattle.io -n jaeger jaeger-operator --type merge -p '
+    { "spec": { "values": {
+          "rbac": { "clusterRole": true },
+          "jaeger": { "create": true }
+    }}}'
+app=jaeger pw test helpers -g 'appReload'
+
+
+# ==================================================================================================
+# enable telemetry & jaeger (controller & defaults)
+
+kubectl patch apps.catalog.cattle.io -n cattle-kubewarden-system rancher-kubewarden-controller --type merge -p '
+    {"spec": {"values": {"telemetry": {
+        "enabled": true,
+        "tracing": {"jaeger": {
+            "endpoint": "jaeger-operator-jaeger-collector.jaeger.svc.cluster.local:14250",
+            "tls": {"insecure": true}
+    }}}}}}'
+
+kubectl patch apps.catalog.cattle.io -n cattle-kubewarden-system rancher-kubewarden-defaults --type merge -p '
+    {"spec": {"values": {"policyServer": {"telemetry": { "enabled": true }}}}}'
+
+app=kubewarden pw test helpers -g 'appReload'
+app=kubewarden-defaults pw test helpers -g 'appReload'
+
+```

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -1,0 +1,20 @@
+// global-setup.js
+const { request } = require('@playwright/test');
+
+module.exports = async () => {
+  const requestContext = await request.newContext({
+    ignoreHTTPSErrors:true,
+    baseURL: process.env.RANCHER_URL //"https://example.com"
+  });
+  await requestContext.post('/v3-public/localProviders/local?action=login', {
+    data: {
+      'username': 'admin',
+      'password': 'sa',
+      'responseType': 'cookie'
+    }
+  });
+
+  // Save signed-in state to 'storageState.json'.
+  await requestContext.storageState({ path: 'storageState.json' });
+  await requestContext.dispose();
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.30.0"
+  }
+}

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,0 +1,100 @@
+// @ts-check
+const { devices } = require('@playwright/test');
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * @type {import('@playwright/test').PlaywrightTestConfig}
+ */
+const config = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 7 * 60 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 10 * 1000
+  },
+  /* Run tests in files in parallel */
+  // fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.RANCHER_URL,
+
+    // headless: false,
+    launchOptions: {slowMo: 100},
+
+    ignoreHTTPSErrors: true,
+    // Tell all tests to load signed-in state from 'storageState.json'.
+    storageState: 'storageState.json',
+
+    screenshot: 'only-on-failure',
+    trace: 'on',  // retain-on-failure
+    // video: 'retain-on-failure',
+  },
+
+  globalSetup: require.resolve('./global-setup'),
+
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: {width:1600, height:900},
+      },
+    },
+
+//    {
+//      name: 'firefox',
+//      use: {
+//        ...devices['Desktop Firefox'],
+//      },
+//    },
+//
+//    {
+//      name: 'webkit',
+//      use: {
+//        ...devices['Desktop Safari'],
+//      },
+//    },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+};
+
+module.exports = config;

--- a/tests/tests/helpers.spec.js
+++ b/tests/tests/helpers.spec.js
@@ -1,0 +1,61 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const charts = [
+  {id: "jaeger", name: 'Jaeger Operator', namespace: 'jaeger', chart: "jaeger-operator"},
+  {id: "monitoring", name: 'Monitoring', project: '(None)', chart: "rancher-monitoring"},
+  {id: "kubewarden", name: 'Kubewarden', project: 'Default', chart: "rancher-kubewarden-controller"},
+  {id: "kubewarden-defaults", chart: "rancher-kubewarden-defaults"},
+]
+
+
+// app=kubewarden pw test helpers -g 'appInstall' --headed
+// app=jaeger npx playwright test helpers -g 'appInstall' --headed
+test('appInstall', async({ page }) => {
+  const app = charts.find(o => o.id === process.env.app) || charts[0]
+
+  // Select chart to be installed
+  await page.goto('/dashboard/c/local/apps/charts')
+  await expect(page.getByRole('heading', { name: 'Charts', exact: true })).toBeVisible()
+  await page.getByRole('main').getByRole('heading', { name: app.name, exact: true }).click()
+  await page.getByRole('button', { name: 'Install' }).click()
+
+  // select namespace or project
+  if (app.namespace !== undefined){
+      await expect(page.getByText('Namespace *')).toBeVisible()
+      await page.getByRole('combobox', { name: 'Search for option' }).click()
+      await page.getByText('Create a New Namespace').click();
+      await page.getByPlaceholder('Create a New Namespace').fill(app.namespace);
+  }
+  if (app.project !== undefined) {
+    await expect(page.getByText('Install into Project')).toBeVisible()
+    await page.getByRole('combobox', { name: 'Search for option' }).click()
+    await page.getByRole('option', { name: app.project }).click()
+  }
+
+  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByRole('button', { name: 'Install' }).click()
+
+  // Fixme SUCCESS: helm install
+  const re = new RegExp(`SUCCESS: helm .* ${app.chart} \/home`)
+  await expect(page.locator('#windowmanager').getByText(re)).toBeVisible({timeout:300_000})
+});
+
+// Upgrade without any changes will reload app yaml (patched by kubectl)
+// app=jaeger npx playwright test helpers -g 'appReload' --headed
+test('appReload', async({ page }) => {
+    const app = charts.find(o => o.id === process.env.app);
+
+    await page.goto('/dashboard/c/local/apps/catalog.cattle.io.app')
+    await expect(page.getByRole('heading', { name: 'Installed Apps' })).toBeVisible()
+
+    await page.locator(`button[id$='+${app?.chart}']`).click()  // id="actionButton+0+rancher-kubewarden-controller"
+    await page.getByText('Edit/Upgrade').click()
+
+    await expect(page.getByRole('heading', { name: app?.chart })).toBeVisible()
+    await page.getByRole('button', { name: 'Next' }).click()
+    await page.getByRole('button', { name: 'Update' }).click()
+
+    const re = new RegExp(`SUCCESS: helm upgrade .* ${app?.chart} \/home`)
+    await expect(page.locator('#windowmanager').getByText(re)).toBeVisible({timeout:300_000})
+});

--- a/tests/tests/installation.spec.js
+++ b/tests/tests/installation.spec.js
@@ -1,0 +1,168 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// you need to wait until cluster is ready before installation
+
+test('00 first run', async({ page }) => {
+  await page.goto('/');
+
+  // login
+  await page.getByRole('textbox').fill('sa');
+  await page.getByTestId('login-submit').click();
+  // end user agreement
+  await page.getByTestId('setup-agreement').locator('.checkbox-custom').check();
+  await page.getByTestId('setup-submit').click();
+  // wait for local cluster to be Active
+  await expect(page.getByTestId('sortable-cell-0-0')).toContainText('Active', {timeout: 30_000})
+});
+
+
+test('01 enable extension support', async({ page }) => {
+  // menu -> configuration -> extensions
+  await page.goto('/dashboard/c/local/uiplugins');
+
+  // click Enable button
+  await page.getByRole('button', { name: 'Enable' }).click();
+  await page.getByRole('button', { name: 'OK' }).click();
+
+  // wait for extension list
+  try {
+    await expect(page.getByRole('tab', { name: 'Installed' })).toBeVisible({timeout: 30_000});
+  } catch (e) {
+    console.log('Reload - Not showing list of extensions')
+    await page.reload();
+    await expect(page.getByRole('tab', { name: 'Installed' })).toBeVisible();
+  }
+
+  // wait for extensions
+  await page.getByRole('tab', { name: 'Available' }).click()
+  await page.waitForTimeout(5000)
+  await page.reload()
+  await expect(page.locator('.plugin', {hasText: 'Kubewarden'} )).toBeVisible();
+});
+
+
+test('02 install kubewarden extension', async({ page }) => {
+  await page.goto('/dashboard/c/local/uiplugins#available')
+  // Install kw extension
+  await page.locator('.plugin', {hasText: /Kubewarden/} ).getByRole('button', { name: 'Install' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Install' }).click();
+  await expect(page.locator('.plugin', {hasText: 'Kubewarden'} ).getByRole('button', { name: 'Uninstall' })).toBeEnabled({timeout: 30_000});
+});
+
+
+test('03 install kubewarden', async({ page }) => {
+  // add kubewarden-charts repository
+  await page.goto('/dashboard/c/local/kubewarden/dashboard')
+  await page.getByRole('button', { name: 'Install Kubewarden' }).click();
+  await page.getByRole('button', { name: 'Add Kubewarden Repository' }).click();
+
+  try {
+    await expect(page.getByRole('button', { name: 'Install Kubewarden' })).toBeEnabled()
+  } catch (e) {
+    console.log('Reload - https://github.com/kubewarden/ui/issues/201')
+    await page.reload();
+    await page.getByRole('button', { name: 'Install Kubewarden' }).click();
+  }
+  await page.getByRole('button', { name: 'Install Kubewarden' }).click();
+  await expect(page.getByRole('heading', { name: 'Install: Step 1' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Install' }).click();
+  await expect(page.locator('#windowmanager').getByText(/SUCCESS: helm upgrade .* rancher-kubewarden-crds/)).toBeVisible({timeout:30_000})
+  await expect(page.locator('#windowmanager').getByText(/SUCCESS: helm upgrade .* rancher-kubewarden-controller/)).toBeVisible({timeout:60_000})
+
+  // check controller is active
+  await page.getByRole('navigation').getByRole('link', { name: 'Kubewarden' }).click()
+  try {
+    await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
+  } catch (e) {
+    console.log('Reload - kubewarden installation done but not detected')
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
+  }
+});
+
+
+test('04 install default policyserver', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/dashboard')
+
+  await page.getByRole('link', { name: 'PolicyServers' }).click()
+  await expect(page.getByRole('heading', { name: 'PolicyServers' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Install Chart' }).click()
+  await expect(page.getByRole('heading', { name: 'Install: Step 1' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByRole('checkbox', { name: 'Enable recommended policies' }).check()
+  await page.getByRole('button', { name: 'Install' }).click();
+
+  await expect(page.locator('#windowmanager').getByText(/SUCCESS: helm upgrade .* rancher-kubewarden-defaults/)).toBeVisible({timeout:40_000})
+  // wait for policy server?
+});
+
+
+test('05 whitelist artifacthub', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy/create')
+  await expect(page.getByRole('heading', { name: 'Custom Policy' })).toBeVisible()
+  await expect(page.locator('.subtype')).toHaveCount(1);
+
+  await expect(page.getByText('Official Kubewarden policies are hosted on ArtifactHub')).toBeVisible()
+  await page.getByRole('button', { name: 'Add ArtifactHub To Whitelist' }).click();
+  
+  await expect(page.getByRole('heading', { name: 'Pod Privileged Policy' })).toBeVisible()
+  await expect(page.locator(".subtype >> nth=25")).toBeVisible() // we have now 27+1 policies
+});
+
+test('06 disable namespace filter', async({ page }) => {
+  await page.goto('/dashboard/c/local/apps/catalog.cattle.io.app')
+  await expect(page.getByRole('heading', { name: 'Installed Apps' })).toBeVisible()
+
+  const allns = page.locator(".ns-filter").filter({ hasText: 'All Namespaces' })
+  if (!await allns.isVisible()) {
+      await page.keyboard.press('n');
+      await page.locator("#all").click();
+      await page.keyboard.press('Escape');
+  }
+  await expect(page.getByText('Namespace: cattle-system')).toBeVisible()
+});
+
+test('10 check overview page', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/dashboard')
+  await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
+
+  await expect(page.getByRole('link', { name: 'Create Policy Server' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Create Admission Policy' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Create Cluster Admission Policy' })).toBeVisible()
+  
+  // kubewarden overview
+  await expect(page.getByText('Active 1 of 1 Pods / 100%')).toBeVisible({timeout:60_000})
+  await expect(page.getByText('Active 6 of 6 Global Policies / 100%')).toBeVisible()
+  await expect(page.getByText('Active 0 of 0 Namespaced Policies / 0%')).toBeVisible()
+});
+
+test('11 check policyservers page', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.policyserver')
+  await expect(page.getByRole('heading', { name: 'PolicyServers' })).toBeVisible()
+
+  await expect(page.locator('.col-policy-server-status')).toHaveCount(1);
+  await expect(page.getByTestId('sortable-cell-0-0')).toHaveText('Active')
+  await expect(page.getByTestId('sortable-cell-0-1')).toHaveText('default')
+  await expect(page.getByTestId('sortable-cell-0-3')).toContainText('6')
+});
+
+test('12 check clusteradmissionpolicies page', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy')
+  await expect(page.getByRole('heading', { name: 'ClusterAdmissionPolicies' })).toBeVisible()
+
+  await expect(page.locator('.col-policy-status')).toHaveCount(6);
+  await expect(page.locator('.col-policy-status').getByText('Active')).toHaveCount(6);
+
+  await expect(page.locator('.col-link-detail').first()).not.toBeEmpty();
+});
+
+test('13 check admissionpolicies page', async({ page }) => {
+  await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.admissionpolicy')
+  await expect(page.getByRole('heading', { name: 'AdmissionPolicies' })).toBeVisible()
+  await expect(page.getByText('There are no rows to show.')).toBeVisible()
+});

--- a/tests/tests/policies.spec..js
+++ b/tests/tests/policies.spec..js
@@ -1,0 +1,100 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe.configure({ mode: 'parallel' });
+
+const policies = process.env.policy?.split("#") || [
+//'Custom Policy',
+  'Allow Privilege Escalation PSP',
+  'Allowed Fs Groups PSP',
+  'Allowed Proc Mount Types PSP',
+  'Apparmor PSP',
+  'Capabilities PSP',
+  'Disallow Service Loadbalancer',
+  'Disallow Service Nodeport',
+  'Environment Variable Secrets Scanner',
+  'Flexvolume Drivers Psp',
+  'Ingress Policy',
+  'Pod Privileged Policy',
+  'Readonly Root Filesystem PSP',
+  'Safe Annotations',
+  'Safe Labels',
+  'Seccomp PSP',
+  'Sysctl PSP',
+  'Trusted Repos',
+  'Volumes PSP']
+
+/* Broken policies
+'Pod Runtime',
+'Hostpaths PSP',
+'User Group PSP',
+'Verify Image Signatures',
+'volumeMounts',
+'Host Namespaces PSP',
+'Selinux PSP',
+'Environment Variable Policy',
+'Deprecated API Versions' ]
+
+
+[clusterwide-test-pod-runtime]
+ - https://github.com/kubewarden/pod-runtime-class-policy/issues/14 (can't create - wrong rules)
+[clusterwide-test-hostpaths-psp] settings are not valid: Some("pathPrefix key is missing; pathPrefix key is missing"),
+ - https://github.com/kubewarden/ui/issues/236
+[clusterwide-test-user-group-psp] settings are not valid: Some("Invalid run_as_user settings: invalid rule."),
+ - https://github.com/kubewarden/user-group-psp-policy/issues/45
+[clusterwide-test-verify-image-signatures] settings are not valid: Some("Error invoking settings validation callback: GuestCallFailure(\"Error decoding validation payload {\\\"modifyImagesWithDigest\\\":true,\\\"rule\\\":\\\"PublicKey\\\",\\\"description\\\":null,\\\"signatures\\\":{\\\"image\\\":\\\"\\\"}}: Error(\\\"invalid type: map, expected a sequence\\\", line: 1, column: 82)\")"), 
+ - https://github.com/kubewarden/ui/issues/239 - invalid yaml
+ - https://github.com/kubewarden/ui/issues/237 - missing options
+[clusterwide-test-volumemounts] settings are not valid: Some("volumeMountsNames is empty"), 
+ - should be required, file UI issue
+[clusterwide-test-host-namespaces-psp] settings are not valid: Some("Error invoking settings validation callback: GuestCallFailure(\"Error decoding validation payload {\\\"allow_host_network\\\":false,\\\"allow_host_ports\\\":{\\\"max\\\":0,\\\"min\\\":0},\\\"allow_host_pid\\\":false,\\\"description\\\":null,\\\"allow_host_ipc\\\":false}: Error(\\\"invalid type: map, expected a sequence\\\", line: 1, column: 47)\")"), 
+ - https://github.com/kubewarden/ui/issues/238 - invalid yaml
+[clusterwide-test-selinux-psp] settings are not valid: Some("you have to provide at least a user, group, type or level settings"), 
+ - https://github.com/kubewarden/ui/issues/240 - extra RunAsAny
+[clusterwide-test-environment-variable-policy] settings are not valid: Some("Error invoking settings validation callback: GuestCallFailure(\"Error decoding validation payload {\\\"description\\\":null,\\\"rules\\\":{\\\"environmentVariables\\\":{\\\"name\\\":\\\"\\\",\\\"value\\\":\\\"\\\"},\\\"reject\\\":\\\"anyIn\\\"}}: Error(\\\"invalid type: map, expected a sequence\\\", line: 1, column: 28)\")"), 
+ - https://github.com/kubewarden/ui/issues/241 invalid yaml
+[clusterwide-test-deprecated-api-versions] settings are not valid: Some("Error invoking settings validation callback: GuestCallFailure(\"Error decoding validation payload {\\\"kubernetes_version\\\":\\\"\\\",\\\"description\\\":null,\\\"deny_on_deprecation\\\":true}: Error(\\\"unexpected end of input while parsing major version number\\\", line: 1, column: 24)\")")
+ - https://github.com/kubewarden/ui/issues/242 - version not required
+
+ */
+
+// generate installation test for every policy
+for (const pol of policies) {
+  test(`install: ${pol}`, async ({ page }) => {
+    const polname = 'test-' + pol.replace(/\s+/g, '-').toLowerCase()
+    const polmode = process.env.mode || 'monitor'
+
+    await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy/create')
+    await expect(page.getByRole('heading', { name: 'Finish: Step 1' })).toBeVisible()
+  
+    await page.getByRole('heading', { name: pol, exact: true }).click()
+    await page.getByRole('button', { name: 'Next' }).click()
+    await page.getByPlaceholder('A unique name').fill(polname)
+    await page.getByRole('radio', {name: polmode}).check()
+    await page.getByRole('button', { name: 'Finish' }).click()
+  
+    await expect(page).toHaveURL(/.*clusteradmissionpolicy$/);   
+    await expect(page.getByRole('link', {name: polname, exact: true})).toBeVisible()
+    // await expect(page
+    //   .locator('tr.main-row')
+    //   .filter({has: page.getByRole('link', {name:polname, exact: true})})
+    //   .locator('td.col-policy-status')
+    // ).toHaveText('Pending')
+  });
+}
+
+test.skip('11 add policyserver', async({ page }) => {
+    // add policy server
+    await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.policyserver/create')
+    await page.getByPlaceholder('A unique name').fill('playwright-ps');
+    await page.getByRole('button', { name: 'Save' }).click();
+  
+    // add policy
+    await page.goto('/dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy/create')
+  
+    await page.getByRole('heading', { name: 'Pod Privileged Policy' }).click()
+    await page.getByRole('button', { name: 'Next' }).click()
+    await page.getByPlaceholder('A unique name').fill('playwright-policy');
+    await page.getByRole('button', { name: 'Finish' }).click();
+  
+  });


### PR DESCRIPTION
Initial version of tests can be started manually with command `npx playwright test installation`.
Requires rancher UI.

```bash
# install k3d
k3d cluster create thecluster -s 1 --wait -v /dev/mapper:/dev/mapper --image rancher/k3s:v1.24.9-k3s2

# install cert-manager
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml

# install rancher
helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
helm repo update rancher-latest

IP_MASTERS=$(k3d cluster list thecluster -o json | jq -r '.[].nodes[] | select(.role == "server").IP.IP')
ranver=$(helm search repo rancher-latest -l --devel | awk '{print $3}' | sort --version-sort | tail -1)

helm upgrade --install rancher rancher-latest/rancher --wait \
    --namespace cattle-system --create-namespace \
    --set hostname=${IP_MASTERS}.nip.io \
    --set bootstrapPassword=sa \
    --set replicas=1 \
    --version=$ranver

# Wait for pods in cattle-system, cattle-fleet-system, cattle-fleet-local-system to be running.

# run UI tests
export RANCHER_URL=https://${IP_MASTERS}.nip.io
npx playwright test installation
```