### PR TITLE
Add YamlEditor to deep sequence questions for policies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     ".drone.yml": true,
     ".editorconfig": true,
     ".eslintcache": true,
-    ".eslintignore": true,
+    ".eslintignore": false,
     ".eslintrc.js": true,
     ".nuxt*": true,
     ".nyc_output": true,

--- a/pkg/kubewarden/components/Questions/Array.vue
+++ b/pkg/kubewarden/components/Questions/Array.vue
@@ -33,6 +33,7 @@ export default {
         :key="question.variable"
         v-model="array"
         :title="question.label"
+        :value-multiline="question.value_multiline"
         :mode="mode"
         :protip="false"
         :disabled="disabled"

--- a/pkg/kubewarden/components/Questions/String.vue
+++ b/pkg/kubewarden/components/Questions/String.vue
@@ -27,7 +27,7 @@ export default {
         :mode="mode"
         :type="inputType"
         :label="displayLabel"
-        :placeholder="question.default"
+        :placeholder="question.placeholder || question.default"
         :required="question.required"
         :value="value"
         :disabled="disabled"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     ]
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests"
   ]
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #254 

Fixed issue with deep sequences in questions for policies by converting the questions into a YamlEditor. This is stop-gap measure to allow the users the ability to update the sequences to a deep level without needing to create a recursive component. 

Other additions:
- Added `value_mutliline` to Array type question to allow full yaml strings in an array string for instances like adding pem certs
- Added placeholder property to String input for questions
- Fixed typescript errors with `./tests` directory