### PR TITLE
Enable only manual workflow on forked repos

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   playwright:
+    if: github.repository_owner == 'kubewarden' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Actions except manual trigger to run only on official repository