### PR TITLE
Add unit-tests for PolicyServer creation/edit

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Authority.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Authority.vue
@@ -11,7 +11,6 @@ export default {
       type:    String,
       default: _EDIT
     },
-
     value: {
       type:    Object,
       default: () => {}

--- a/tests/unit/charts/admission/Admission.spec.ts
+++ b/tests/unit/charts/admission/Admission.spec.ts
@@ -8,8 +8,8 @@ import Settings from '@kubewarden/chart/kubewarden/admission/Settings.vue';
 import Questions from '@kubewarden/components/Questions/index.vue';
 
 import { DEFAULT_POLICY } from '@kubewarden/plugins/policy-class';
-import policyConfig from '../templates/policyConfig';
-import { question } from '../templates/questions';
+import policyConfig from '../../templates/policyConfig';
+import { question } from '../../templates/questions';
 
 describe('component: Rules', () => {
   it('settings component should be shown when custom policy', () => {

--- a/tests/unit/charts/admission/Authority.spec.ts
+++ b/tests/unit/charts/admission/Authority.spec.ts
@@ -1,0 +1,52 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import Authority from '@kubewarden/chart/kubewarden/policy-server/Registry/Authority.vue';
+import { LabeledInput } from '@components/Form/LabeledInput';
+
+const authorityObj = {
+  'registry-pre.example.com': [
+    '-----BEGIN CERTIFICATE-----\nca-pre1-1 PEM cert\n-----END CERTIFICATE-----\n',
+    '-----BEGIN CERTIFICATE-----\nca-pre1-2 PEM cert\n-----END CERTIFICATE-----'
+  ]
+};
+
+const row = () => {
+  let out = {};
+
+  for ( const [key, value] of Object.entries(authorityObj) ) {
+    out = {
+      registryName: key,
+      certs:        value
+    };
+  }
+
+  return out;
+};
+
+describe('component: Authority', () => {
+  it('renders authorityObj key as registryName', () => {
+    const wrapper = shallowMount(Authority as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: row() },
+      stubs:     { FileSelector: { template: '<span />' } }
+    });
+
+    const registryName = wrapper.findAllComponents(LabeledInput).at(0);
+
+    expect(registryName.props().value).toStrictEqual(wrapper.props().value?.registryName as String);
+  });
+
+  it('renders all certs from authorityObj', () => {
+    const wrapper = shallowMount(Authority as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: row() },
+      stubs:     { FileSelector: { template: '<span />' } }
+    });
+
+    const authorityCerts = wrapper.findAllComponents(LabeledInput);
+
+    expect(authorityCerts.at(1).props().value).toStrictEqual(wrapper.props().value?.certs[0] as String);
+    expect(authorityCerts.at(2).props().value).toStrictEqual(wrapper.props().value?.certs[1] as String);
+  });
+});

--- a/tests/unit/charts/admission/General.spec.ts
+++ b/tests/unit/charts/admission/General.spec.ts
@@ -8,7 +8,7 @@ import General from '@kubewarden/chart/kubewarden/admission/General.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { RadioGroup } from '@components/Form/Radio';
 
-import policyConfig from '../templates/policyConfig';
+import policyConfig from '../../templates/policyConfig';
 
 describe('component: General', () => {
   it('should display the PolicyServer options if available', () => {

--- a/tests/unit/charts/admission/Rules.spec.ts
+++ b/tests/unit/charts/admission/Rules.spec.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from '@jest/globals';
 import Rules from '@kubewarden/chart/kubewarden/admission/Rules.vue';
 import Rule from '@kubewarden/chart/kubewarden/admission/Rule.vue';
 
-import policyConfig from '../templates/policyConfig';
+import policyConfig from '../../templates/policyConfig';
 
 describe('component: Rules', () => {
   it('rules should render rule components based on policy config', async() => {

--- a/tests/unit/charts/policy-server/General.spec.ts
+++ b/tests/unit/charts/policy-server/General.spec.ts
@@ -1,0 +1,43 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import General from '@kubewarden/chart/kubewarden/policy-server/General.vue';
+import ServiceNameSelect from '@shell/components/form/ServiceNameSelect';
+
+import { DEFAULT_POLICY_SERVER } from '@kubewarden/models/policies.kubewarden.io.policyserver.js';
+
+describe('component: General', () => {
+  it('displays service account options', () => {
+    const serviceAccounts = ['sa-1', 'sa-2', 'sa-3'];
+
+    const wrapper = shallowMount(General as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: DEFAULT_POLICY_SERVER, serviceAccounts },
+      stubs:     {
+        LabeledInput:      { template: '<span />' },
+        RadioGroup:        { template: '<span />' }
+      }
+    });
+
+    const selector = wrapper.findComponent(ServiceNameSelect);
+
+    expect(selector.props().options).toStrictEqual(serviceAccounts as Array<String>);
+  });
+
+  it('displays correct service account when existing', () => {
+    const serviceAccounts = ['sa-1', 'sa-2', 'sa-3'];
+
+    const name = { spec: { serviceAccountName: serviceAccounts[1] } };
+    const policyServer = { ...DEFAULT_POLICY_SERVER, ...name };
+
+    const wrapper = shallowMount(General as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: policyServer, serviceAccounts },
+      stubs:     { Banner: { template: '<span />' } }
+    });
+
+    const selector = wrapper.findComponent(ServiceNameSelect);
+
+    expect(selector.props().value).toStrictEqual(serviceAccounts[1] as String);
+  });
+});

--- a/tests/unit/charts/policy-server/Verification.spec.ts
+++ b/tests/unit/charts/policy-server/Verification.spec.ts
@@ -1,0 +1,37 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import Verification from '@kubewarden/chart/kubewarden/policy-server/Verification.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+
+import { DEFAULT_POLICY_SERVER } from '@kubewarden/models/policies.kubewarden.io.policyserver.js';
+
+describe('component: Verification', () => {
+  it('displays configmap options', () => {
+    const configMaps = ['cm-1', 'cm-2', 'cm-3'];
+
+    const wrapper = shallowMount(Verification as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: DEFAULT_POLICY_SERVER, configMaps },
+      stubs:     { Banner: { template: '<span />' } }
+    });
+
+    const selector = wrapper.findComponent(LabeledSelect);
+
+    expect(selector.props().options).toStrictEqual(configMaps as Array<String>);
+  });
+
+  it('displays correct configmap when existing', () => {
+    const configMaps = ['cm-1', 'cm-2', 'cm-3'];
+
+    const wrapper = shallowMount(Verification as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: { verificationConfig: 'cm-2' }, configMaps },
+      stubs:     { Banner: { template: '<span />' } }
+    });
+
+    const selector = wrapper.findComponent(LabeledSelect);
+
+    expect(selector.props().value).toStrictEqual('cm-2' as String);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #268 

Adds unit-tests to policy server creation and edit components.
