### PR TITLE
Add unit-tests for DashboardView component

### DIFF
--- a/tests/unit/charts/policy-server/Verification.spec.ts
+++ b/tests/unit/charts/policy-server/Verification.spec.ts
@@ -26,12 +26,12 @@ describe('component: Verification', () => {
     const configMaps = ['cm-1', 'cm-2', 'cm-3'];
 
     const wrapper = shallowMount(Verification as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData: { value: { verificationConfig: 'cm-2' }, configMaps },
+      propsData: { value: { verificationConfig: configMaps[1] }, configMaps },
       stubs:     { Banner: { template: '<span />' } }
     });
 
     const selector = wrapper.findComponent(LabeledSelect);
 
-    expect(selector.props().value).toStrictEqual('cm-2' as String);
+    expect(selector.props().value).toStrictEqual(configMaps[1] as String);
   });
 });

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -1,0 +1,148 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import DashboardView from '@kubewarden/components/Dashboard/DashboardView.vue';
+import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
+import ConsumptionGauge from '@shell/components/ConsumptionGauge';
+
+describe('component: General', () => {
+  it('renders defaults banner when default app is not found', () => {
+    const wrapper = shallowMount(DashboardView as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      computed:  {
+        defaultsApp:        () => null,
+        hideDefaultsBanner: () => false,
+        policyServerPods:   () => [],
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [],
+        version:            () => '1.25'
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn(),
+            'kubewarden/hideDefaultsBanner': jest.fn()
+          },
+        }
+      },
+      stubs: {
+        Card:             { template: '<span />' },
+        ConsumptionGauge: { template: '<span />' }
+      }
+    });
+
+    const banner = wrapper.findComponent(DefaultsBanner);
+
+    expect(banner.exists()).toBe(true);
+  });
+
+  it('renders correct gauge info of policy servers', () => {
+    const pods = [
+      {
+        metadata: {
+          state: {
+            name:          'running',
+            error:         false,
+            transitioning: false
+          }
+        }
+      },
+      {
+        metadata: {
+          state: {
+            name:          'pending',
+            error:         false,
+            transitioning: true
+          }
+        }
+      }
+    ];
+
+    const wrapper = shallowMount(DashboardView as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      computed:  {
+        defaultsApp:        () => null,
+        policyServerPods:   () => pods,
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [],
+        version:            () => '1.25'
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn(),
+            'kubewarden/hideDefaultsBanner': jest.fn()
+          },
+        }
+      },
+      stubs: { DefaultsBanner: { template: '<span />' } }
+    });
+
+    const gauges = wrapper.findAllComponents(ConsumptionGauge);
+
+    expect(gauges.at(0).props().capacity).toStrictEqual(pods.length as Number);
+    expect(gauges.at(0).props().used).toStrictEqual(1 as Number);
+  });
+
+  it('renders correct gauge info of admission policies', () => {
+    const policies = [
+      {
+        status: {
+          policyStatus: 'active',
+          error:        false,
+        },
+        spec: { mode: 'protect' }
+      },
+      {
+        status: {
+          policyStatus: 'pending',
+          error:        false,
+        },
+        spec: { mode: 'protect' }
+      },
+      {
+        status: {
+          policyStatus: 'unschedulable',
+          error:        true,
+        },
+        spec: { mode: 'monitor' }
+      }
+    ];
+
+    const wrapper = shallowMount(DashboardView as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      computed:  {
+        defaultsApp:        () => null,
+        policyServerPods:   () => [],
+        globalPolicies:     () => [],
+        namespacedPolicies: () => policies,
+        version:            () => '1.25'
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn(),
+            'kubewarden/hideDefaultsBanner': jest.fn()
+          },
+        }
+      },
+      stubs: { DefaultsBanner: { template: '<span />' } }
+    });
+
+    const gauges = wrapper.findAllComponents(ConsumptionGauge);
+
+    expect(gauges.at(1).props().capacity).toStrictEqual(policies.length as Number);
+    expect(gauges.at(1).props().used).toStrictEqual(1 as Number);
+  });
+});

--- a/tests/unit/components/Questions/SequenceTree.spec.ts
+++ b/tests/unit/components/Questions/SequenceTree.spec.ts
@@ -5,7 +5,8 @@ import { describe, expect, it } from '@jest/globals';
 
 import Question from '@kubewarden/components/Questions/index.vue';
 import SequenceType from '@kubewarden/components/Questions/SequenceTree.vue';
-import { question, deepQuestion } from '../templates/questions';
+
+import { question, deepQuestion } from '../../templates/questions';
 
 function getGroups(flattenedQuestions) {
   const map = {};


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #269 

Adds unit-tests for the DashboardView component. Tests if the defaults chart banner is displayed and if the consumption gauges display the correct information.
