### PR TITLE
Fix issue with a deep questionMap component within a sequence

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -278,8 +278,8 @@ export default ({
         metadata:   { annotations: { [ARTIFACTHUB_PKG_ANNOTATION]: packageAnnotation } },
         spec:       {
           module:       policyDetails.containers_images[0].image,
-          contextAware: JSON.parse(policyDetails?.data?.['kubewarden/contextAware']) || false,
-          mutating:     JSON.parse(policyDetails?.data?.['kubewarden/mutation']) || false,
+          contextAware: policyDetails?.data?.['kubewarden/contextAware'] ? JSON.parse(policyDetails.data['kubewarden/contextAware']) : false,
+          mutating:     policyDetails?.data?.['kubewarden/mutation'] ? JSON.parse(policyDetails.data['kubewarden/mutation']) : false,
           rules:        packageRules?.rules || []
         }
       };


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #296 

This fixes an issue with policy questions that contain a `map[` type within a `sequence[` question, which was preventing the ability to add, remove, or update the subquestions contained in the map.