### PR TITLE
Fix issue with policy annotations fetched from artifact hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.0.3",
+  "version": "1.0.4-rc1",
   "private": false,
   "scripts": {
     "build": "./node_modules/.bin/nuxt build",
@@ -31,6 +31,7 @@
     "babel-jest": "^28.0.0-alpha.1",
     "jest": "^28.0.0-alpha.1",
     "jest-environment-jsdom": "^29.4.3",
+    "sass-loader": "10.1.1",
     "ts-jest": "^29.0.5",
     "ts-loader": "~8.2.0",
     "typescript": "4.1.6",

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -272,14 +272,22 @@ export default ({
       const packageQuestions = this.value.parsePackageMetadata(policyDetails?.data?.['kubewarden/questions-ui']);
       const packageAnnotation = `${ policyDetails.repository.name }/${ policyDetails.name }/${ policyDetails.version }`;
 
+      const determineAnnotation = (annotation) => {
+        if ( policyDetails?.data?.[annotation] !== undefined ) {
+          return JSON.parse(policyDetails.data[annotation]);
+        }
+
+        return false;
+      };
+
       const updatedPolicy = {
         apiVersion: this.value.apiVersion,
         kind:       this.value.kind,
         metadata:   { annotations: { [ARTIFACTHUB_PKG_ANNOTATION]: packageAnnotation } },
         spec:       {
           module:       policyDetails.containers_images[0].image,
-          contextAware: policyDetails?.data?.['kubewarden/contextAware'] ? JSON.parse(policyDetails.data['kubewarden/contextAware']) : false,
-          mutating:     policyDetails?.data?.['kubewarden/mutation'] ? JSON.parse(policyDetails.data['kubewarden/mutation']) : false,
+          contextAware: determineAnnotation('kubewarden/contextAware'),
+          mutating:     determineAnnotation('kubewarden/mutation'),
           rules:        packageRules?.rules || []
         }
       };

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.0.3",
+  "version": "1.0.4-rc1",
   "private": false,
   "rancher": true,
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16352,6 +16352,17 @@ safe-regex@^2.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass-loader@10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.1.1.tgz#4ddd5a3d7638e7949065dd6e9c7c04037f7e663d"
+  integrity sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==
+  dependencies:
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
+
 sass-loader@10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.1.tgz#17e51df313f1a7a203889ce8ff91be362651276e"


### PR DESCRIPTION
## Description

This fixes an issue with the two annotations `kubewarden/contextAware` and `kubewarden/mutation` that are being parsed from the ArtifactHub package data for a policy.