### PR TITLE
Fix issue with undefined policy rules from package data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.0.4-rc1",
+  "version": "1.0.4-rc2",
   "private": false,
   "scripts": {
     "build": "./node_modules/.bin/nuxt build",

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -268,9 +268,17 @@ export default ({
       }
 
       const policyDetails = this.packages.find(pkg => pkg.name === this.type?.name);
-      const packageRules = this.value.parsePackageMetadata(policyDetails?.data?.['kubewarden/rules']);
       const packageQuestions = this.value.parsePackageMetadata(policyDetails?.data?.['kubewarden/questions-ui']);
       const packageAnnotation = `${ policyDetails.repository.name }/${ policyDetails.name }/${ policyDetails.version }`;
+      const packageRules = () => {
+        const out = this.value.parsePackageMetadata(policyDetails?.data?.['kubewarden/rules']);
+
+        if ( out?.rules !== undefined ) {
+          return out.rules;
+        }
+
+        return out || [];
+      };
 
       const determineAnnotation = (annotation) => {
         if ( policyDetails?.data?.[annotation] !== undefined ) {
@@ -288,7 +296,7 @@ export default ({
           module:       policyDetails.containers_images[0].image,
           contextAware: determineAnnotation('kubewarden/contextAware'),
           mutating:     determineAnnotation('kubewarden/mutation'),
-          rules:        packageRules?.rules || []
+          rules:        packageRules()
         }
       };
 

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.0.4-rc1",
+  "version": "1.0.4-rc2",
   "private": false,
   "rancher": true,
   "scripts": {


### PR DESCRIPTION
## Description

This fixes an issue with the policy rules being undefined when fetching data from ArtifactHub. With the recent updates to the ArtifactHub metadata, the `rules` property within the `kubewarden/rules` annotation has been removed, the UI needed to account for this change.
