### PR TITLE
Fix playwright policy filter

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -139,19 +139,20 @@ jobs:
     # ==================================================================================================
     # Setup playwright ENV and run tests
     # https://rancher.github.io/dashboard/testing/e2e-test#setup-for-local-tests
+    - name: Setup Playwright ENV
+      run: |
+        RANCHER_URL=https://${{env.RANCHER_FQDN}}
+        if [ "${{ env.KUBEWARDEN }}" == 'source' ]; then
+          API=$RANCHER_URL
+          RANCHER_URL=https://localhost:8005
+        fi
+        [ -v API ] && echo API=$API | tee -a $GITHUB_ENV
+        echo RANCHER_URL=$RANCHER_URL | tee -a $GITHUB_ENV
+        echo ORIGIN=${{ env.KUBEWARDEN }} | tee -a $GITHUB_ENV
+      
     - name: Install kubewarden
       working-directory: tests
       run: |
-        export RANCHER_URL=https://${{env.RANCHER_FQDN}}
-        if [ "${{ env.KUBEWARDEN }}" == 'source' ]; then
-          export API=$RANCHER_URL
-          export RANCHER_URL=https://localhost:8005
-        fi
-        export ORIGIN=${{ env.KUBEWARDEN }}
-
-        echo API=$API
-        echo RANCHER_URL=$RANCHER_URL
-      
         npx playwright test installation -x
 
 
@@ -160,8 +161,7 @@ jobs:
       timeout-minutes: 90
       working-directory: tests
       run: |
-        [ -n "${{ inputs.policyfilter }}" ] && FILTER='${{ inputs.policyfilter }}'
-        npx playwright test policies ${FILTER:+-g "$FILTER"}
+        npx playwright test policies -g "${{ inputs.policyfilter || '' }}" -x
 
     # ==================================================================================================
     # Artifacts & Summary

--- a/tests/tests/installation.spec.js
+++ b/tests/tests/installation.spec.js
@@ -4,7 +4,7 @@ const jsyaml = require('js-yaml');
 const merge = require('lodash.merge');
 
 // source (yarn dev) | rc (add devel repo) | released (just install)
-const ORIGIN = process.env.ORIGIN || 'rc' // use source if API is set
+const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'rc')
 
 /**
  * @param {import('@playwright/test').Page} page

--- a/tests/tests/policies.spec.js
+++ b/tests/tests/policies.spec.js
@@ -9,7 +9,7 @@ const polkeep   = process.env.keep || false
 
 const policies = [
   { name: 'Custom Policy', action: setupCustomPolicy },
-  { name: 'Allow Privilege Escalation PSP', skip: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy/issues/48' },
+  { name: 'Allow Privilege Escalation PSP' },
   { name: 'Allowed Fs Groups PSP' },
   { name: 'Allowed Proc Mount Types PSP' },
   { name: 'Apparmor PSP' },


### PR DESCRIPTION
Playwright ENV was set up only for installation, but not for policy tests.
Policy tests then failed because of RANCHER_URL variable.

Fix for: https://github.com/kubewarden/ui/actions/runs/4626181244/jobs/8182648493
Local run: https://github.com/kravciak/ui/actions/runs/4626663643/jobs/8183657427

Other improvements:
 - simplify filter for policy tests
 - [Allow Privilege Escalation PSP was fixed](https://github.com/kubewarden/allow-privilege-escalation-psp-policy/issues/48), enable test again
 - set ORIGIN variable default (variable sets source of kubewarden extension)
   - if `API` variable is set we are building extension from source
   - otherwise use last release from kubewarden/ui repository