### PR TITLE
Add more robust conditionals for artifacthub packages

### DIFF
--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -59,7 +59,7 @@ export default {
 
         if ( this.keywords ) {
           for ( const selected of this.keywords ) {
-            if ( !subtype.keywords.includes(selected) ) {
+            if ( !subtype.keywords?.includes(selected) ) {
               return false;
             }
           }
@@ -73,7 +73,9 @@ export default {
 
     keywordOptions() {
       const flattened = this.value?.flatMap((subtype) => {
-        return subtype.keywords;
+        if ( subtype.keywords && subtype.keywords.length ) {
+          return subtype.keywords;
+        }
       }).sort();
 
       return [...new Set(flattened)] || [];
@@ -81,17 +83,24 @@ export default {
 
     resourceOptions() {
       const out = [];
+
       const resources = this.value?.flatMap((subtype) => {
-        return subtype.data?.['kubewarden/resources'];
+        const annotation = subtype.data?.['kubewarden/resources'];
+
+        if ( annotation ) {
+          return annotation;
+        }
       });
 
       resources?.flatMap((resource) => {
-        const split = resource.split(',');
+        if ( resource ) {
+          const split = resource.split(',');
 
-        if ( split.length > 1 ) {
-          split.forEach(s => out.push(s));
-        } else {
-          out.push(resource);
+          if ( split.length > 1 ) {
+            split.forEach(s => out.push(s));
+          } else {
+            out.push(resource);
+          }
         }
       }).sort();
 
@@ -107,9 +116,13 @@ export default {
     },
 
     resourceType(type) {
-      const t = type.split(',');
+      if ( type === undefined ) {
+        return null;
+      }
 
-      if ( t.length > 1 ) {
+      const t = type?.split(',');
+
+      if ( t?.length > 1 ) {
         return 'Multiple';
       }
 
@@ -174,7 +187,7 @@ export default {
         @click="$emit('selectType', subtype)"
       >
         <div class="subtype__metadata">
-          <div class="subtype__badge">
+          <div v-if="subtype.data['kubewarden/resources']" class="subtype__badge">
             <label>{{ resourceType(subtype.data['kubewarden/resources']) }}</label>
           </div>
 
@@ -184,13 +197,13 @@ export default {
             </span>
           </div>
 
-          <div v-if="subtype.data['kubewarden/mutation'] === 'true'" class="subtype__mutation">
+          <div v-if="subtype.data['kubewarden/mutation']" class="subtype__mutation">
             <span v-tooltip="t('kubewarden.policyCharts.mutationPolicy.tooltip')">
               {{ t('kubewarden.policyCharts.mutationPolicy.label') }}
             </span>
           </div>
 
-          <div v-if="subtype.data['kubewarden/contextAware'] === 'true'" class="subtype__aware">
+          <div v-if="subtype.data['kubewarden/contextAware']" class="subtype__aware">
             <span>
               {{ t('kubewarden.policyCharts.contextAware') }}
             </span>

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -10,7 +10,7 @@ import { CONFIG_MAP, MANAGEMENT, SERVICE } from '@shell/config/types';
 import { findBy, isArray } from '@shell/utils/array';
 import { addParams } from '@shell/utils/url';
 
-import { KUBEWARDEN, METRICS_DASHBOARD } from '../types';
+import { KUBEWARDEN, KUBEWARDEN_PRODUCT_NAME, METRICS_DASHBOARD } from '../types';
 import policyServerDashboard from '../assets/kubewarden-metrics-policyserver.json';
 import policyDashboard from '../assets/kubewarden-metrics-policy.json';
 
@@ -128,8 +128,11 @@ export default class KubewardenModel extends SteveModel {
       let url = '/meta/proxy/';
       const packages = 'packages/search';
       const params = {
-        kind:  13, // Kind for Kubewarden policies https://artifacthub.io/packages/search?kind=13
-        limit: 50, // Limit request count
+        org:                KUBEWARDEN_PRODUCT_NAME, // Limit to the Kubewarden organization
+        kind:               13, // Kind for Kubewarden policies
+        verified_publisher: true, // Require verified publisher
+        official:           true, // Ensure package is official
+        limit:              50 // limit to 50, default is 20
       };
 
       url += `${ ARTIFACTHUB_ENDPOINT }/${ packages }`;


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #312

This adds more robust conditionals to the PolicyGrid component which loads:
- resource/keyword options
- resource badge
- mutation/context aware badges

Also makes the package fetching constrained to ([example api fetch](https://artifacthub.io/api/v1/packages/search?kind=13&org=kubewarden&verified_publisher=true&official=true)):
- Kubewarden policy types
- The Kubewarden organization name
- A verified publisher
- An official publisher