### PR TITLE
Fix controller and defaults chart route to lastest stable version

### DIFF
--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -1,13 +1,22 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import { CATALOG } from '@shell/config/types';
+import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+
 import { Banner } from '@components/Banner';
+
 import { KUBEWARDEN_CHARTS } from '../types';
+import { getLatestStableVersion } from '../plugins/kubewarden-class';
 
 export default {
   components: { Banner },
 
+  mixins: [ResourceFetch],
+
   computed: {
+    ...mapGetters(['currentCluster']),
     ...mapGetters({ allRepos: 'catalog/repos' }),
 
     defaultsChart() {
@@ -28,10 +37,11 @@ export default {
       try {
         await this.$store.dispatch('catalog/load', { force: true, reset: true });
       } catch (e) {
-        this.$store.dispatch('growl/fromError', e);
+        this.handleGrowlError(e);
       }
 
       if ( !this.defaultsChart && retry === 0 ) {
+        await this.$fetchType(CATALOG.CLUSTER_REPO);
         await this.refreshCharts(retry + 1);
       }
     },
@@ -41,13 +51,39 @@ export default {
         try {
           await this.refreshCharts();
         } catch (e) {
-          this.$store.dispatch('growl/fromError', e);
+          this.handleGrowlError(e);
 
           return;
         }
       }
 
-      this.defaultsChart.goToInstall(KUBEWARDEN_CHARTS.DEFAULTS);
+      const {
+        repoType, repoName, chartName, versions
+      } = this.defaultsChart;
+      const latestStableVersion = getLatestStableVersion(versions);
+
+      const query = {
+        [REPO_TYPE]: repoType,
+        [REPO]:      repoName,
+        [CHART]:     chartName,
+        [VERSION]:   latestStableVersion.version
+      };
+
+      this.$router.push({
+        name:   'c-cluster-apps-charts-install',
+        params: { cluster: this.currentCluster?.id || '_' },
+        query,
+      });
+    },
+
+    handleGrowlError(e) {
+      const error = e?.data || e;
+
+      this.$store.dispatch('growl/error', {
+        title:   error._statusText,
+        message: error.message,
+        timeout: 5000,
+      }, { root: true });
     }
   }
 };

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -553,3 +553,23 @@ export function colorForTraceStatus(status) {
 
   return 'success';
 }
+
+export function getLatestStableVersion(versions) {
+  const stableVersions = versions.filter(v => !v.version.includes('rc'));
+
+  return stableVersions?.sort((a, b) => {
+    const versionA = a.version.split('.').map(Number);
+    const versionB = b.version.split('.').map(Number);
+
+    for ( let i = 0; i < Math.max(versionA.length, versionB.length); i++ ) {
+      if ( versionA[i] === undefined || versionA[i] < versionB[i] ) {
+        return 1;
+      }
+      if ( versionB[i] === undefined || versionA[i] > versionB[i] ) {
+        return -1;
+      }
+    }
+
+    return 0;
+  })[0];
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #315 

This fixes the generated chart routes for both the `kubewarden-controller` and `kubewarden-defaults` charts by determining the latest stable version for each chart, then applying that to the route query params. 