### PR TITLE
Clean empty policy values gained from questions

### DIFF
--- a/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
@@ -3,6 +3,8 @@ import { _CREATE, _EDIT } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
+import { removeEmptyAttrs } from '../utils/object';
+
 import Config from '../components/Policies/Config';
 import Create from '../components/Policies/Create';
 
@@ -45,8 +47,18 @@ export default {
   methods: {
     async finish(event) {
       try {
+        removeEmptyAttrs(this.value);
+
         await this.save(event);
-      } catch (e) {}
+      } catch (e) {
+        const error = e?.data || e;
+
+        this.$store.dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 5000,
+        }, { root: true });
+      }
     },
   }
 };

--- a/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -3,6 +3,8 @@ import { _CREATE, _EDIT } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
+import { removeEmptyAttrs } from '../utils/object';
+
 import Config from '../components/Policies/Config';
 import Create from '../components/Policies/Create';
 
@@ -45,9 +47,17 @@ export default {
   methods: {
     async finish(event) {
       try {
+        removeEmptyAttrs(this.value);
+
         await this.save(event);
       } catch (e) {
-        this.errors.push(e);
+        const error = e?.data || e;
+
+        this.$store.dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 5000,
+        }, { root: true });
       }
     },
   }

--- a/pkg/kubewarden/utils/object.ts
+++ b/pkg/kubewarden/utils/object.ts
@@ -1,0 +1,16 @@
+import isEmpty from 'lodash/isEmpty';
+import isObject from 'lodash/isObject';
+
+export function removeEmptyAttrs(obj: any) {
+  Object.keys(obj).forEach((key: any) => {
+    const value = obj[key];
+
+    if ( !value || value === '' || (Array.isArray(value) && !value.length) || (isObject(value) && isEmpty(value)) ) {
+      delete obj[key];
+    } else if ( isObject(value) ) {
+      removeEmptyAttrs(value);
+    }
+  });
+
+  return obj;
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #308  Fix #262

This adds a utility method to remove empty attributes from policies when creating/editing a policy. The questions for each policy package would leave default values which were causing issues with the policy validation. 
Now when a policy is created or edited, any leftover objects/arrays/strings that are empty, null, or undefined will be removed.  