### PR TITLE
Add check for policy server versions through defaults chart

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -170,6 +170,7 @@ kubewarden:
     defaultImage:
       label: Default Image
       tooltip: Use the default `policy-server` container image.
+      versionWarning: The latest stable version for Policy Server could not be determined, falling back to default.
     image:
       label: Image URL
       tooltip: This is the container image the policy server.

--- a/tests/unit/charts/policy-server/General.spec.ts
+++ b/tests/unit/charts/policy-server/General.spec.ts
@@ -14,6 +14,23 @@ describe('component: General', () => {
 
     const wrapper = shallowMount(General as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { value: DEFAULT_POLICY_SERVER, serviceAccounts },
+      computed:  {
+        isCreate:      () => false,
+        defaultsChart: () => null
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentStore:                 () => 'current_store',
+            'current_store/all':          jest.fn(),
+            'i18n/t':                     jest.fn(),
+            'management/byId':            jest.fn(),
+            'resource-fetch/refreshFlag': jest.fn()
+          },
+          dispatch: jest.fn()
+        }
+      },
       stubs:     {
         LabeledInput:      { template: '<span />' },
         RadioGroup:        { template: '<span />' }
@@ -33,7 +50,24 @@ describe('component: General', () => {
 
     const wrapper = shallowMount(General as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { value: policyServer, serviceAccounts },
-      stubs:     { Banner: { template: '<span />' } }
+      computed:  {
+        isCreate:      () => false,
+        defaultsChart: () => null
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentStore:                 () => 'current_store',
+            'current_store/all':          jest.fn(),
+            'i18n/t':                     jest.fn(),
+            'management/byId':            jest.fn(),
+            'resource-fetch/refreshFlag': jest.fn()
+          },
+          dispatch: jest.fn()
+        }
+      },
+      stubs: { Banner: { template: '<span />' } }
     });
 
     const selector = wrapper.findComponent(ServiceNameSelect);


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #317 

This adds a check for the latest stable version of Policy Server when creating a new Policy Server resource.

In order to check for the latest stable version, the `kubewarden-defaults` chart must be accessible as this is the only way to fetch info from the outside world without adding endpoints to the whitelist settings. If the Kubewarden helm repo and defaults chart can not be found the version will fall back to the default (e.g. `latest`) with a banner displaying this info to the user. 