### PR TITLE
Ensure max kube-version is 1.26

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,25 +1,5 @@
 apiVersion: v1
 entries:
-  harvester-manager:
-  - annotations:
-      catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
-      catalog.cattle.io/namespace: cattle-ui-plugin-system
-      catalog.cattle.io/os: linux
-      catalog.cattle.io/permits-os: linux, windows
-      catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
-      catalog.cattle.io/scope: management
-      catalog.cattle.io/ui-component: plugins
-    apiVersion: v2
-    appVersion: 0.1.0
-    created: "2023-02-09T16:43:57.72563315Z"
-    description: harvester-manager plugin
-    digest: e48fd0d9c5f4475182675a3fadfb5bba94ae5d3c82fb2fb2a1d472e911eca47d
-    name: harvester-manager
-    type: application
-    urls:
-    - assets/harvester-manager/harvester-manager-0.1.0.tgz
-    version: 0.1.0
   kubewarden:
   - annotations:
       catalog.cattle.io/certified: rancher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.0.4",
+  "version": "1.0.5-rc1",
   "private": false,
   "scripts": {
     "build": "./node_modules/.bin/nuxt build",

--- a/scripts/publish
+++ b/scripts/publish
@@ -283,6 +283,9 @@ for d in pkg/*/ ; do
     # Additional patches
     ${SCRIPT_DIR}/helmpatch ${CHART_FOLDER} "${BASE_DIR}/pkg/${pkg}/package.json" "${GITHUB_SOURCE}"
 
+    # Ensure max kube-version annotation is up to date
+    yq -i eval '.annotations."catalog.cattle.io/kube-version" = ">= 1.16.0-0 < 1.26.0-0"' $CHART_FOLDER/Chart.yaml
+
     # Package into a .tgz helm chart
     helm package ${CHART_FOLDER} -d ${ASSETS}/${pkg}
 
@@ -326,9 +329,3 @@ cp -r ${PKG_ASSET} tmp/assets/$pkg
 cp -r ${CHARTS}/${pkg}/${PKG_VERSION} tmp/charts/$pkg
 cp -r ${EXT_FOLDER} tmp/extensions/$pkg
 cp index.yaml tmp
-
-# If the user asked to create a commit, commit the changes
-# if [ "${COMMIT}" == "true" ]; then
-#   echo -e "${CYAN}${BOLD}Creating git commit${RESET}"
-#   git add --all
-# fi


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #321 

This will ensure the max `catalog.cattle.io/kube-version` is `1.26` which is shipped by Rancher v2.7.2 by default.
Also releasing `1.0.5-rc1`