### PR TITLE
Add provider filtering for artifacthub policies

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -428,7 +428,7 @@ export default ({
       <template #policies>
         <PolicyGrid :value="packages" @selectType="selectType($event)">
           <template #customSubtype>
-            <div class="subtype" @click="selectType('custom')">
+            <div class="subtype custom" @click="selectType('custom')">
               <div class="subtype__metadata">
                 <div class="subtype__badge" :style="{ 'background-color': 'var(--darker)' }">
                   <label>{{ t('kubewarden.customPolicy.badge') }}</label>
@@ -497,10 +497,14 @@ $color: var(--body-text) !important;
 }
 
 ::v-deep .controls-row {
-    .controls-steps {
-      display: flex;
-    }
+  .controls-steps {
+    display: flex;
   }
+}
+
+::v-deep .custom {
+  min-height: 110px;
+}
 
 ::v-deep .subtype {
   height: $height;

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -111,7 +111,11 @@ kubewarden:
     noArtifactHub: Official Kubewarden policies are hosted on <a href="https://artifacthub.io/packages/search?kind=13" target="_blank" rel="noopener noreferrer nofollow">ArtifactHub</a>, in order to show these you will need to add `artifacthub.io` to the whitelist-domain setting.
     noRules: There are no rules configured for this policy.
     namespaceWarning: This policy is targeting Rancher specific namespaces which will cause catastrophic failures with your Rancher deployment.
+    official: Official Kubewarden Policy
   utils:
+    keyword: Filter by Keyword
+    provider: Filter by Provider
+    resource: Filter by Resource Type
     resetFilter: Reset Filter
   tracing:
     noJaeger: |
@@ -197,7 +201,7 @@ kubewarden:
   policyCharts:
     signedPolicy:
       label: Signed
-      tooltip: This policy has been signed with cosign (Sigstore).
+      tooltip: This policy has been signed with { signatures }.
     mutationPolicy:
       label: Mutation
       tooltip: Mutation Policy

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -128,10 +128,7 @@ export default class KubewardenModel extends SteveModel {
       let url = '/meta/proxy/';
       const packages = 'packages/search';
       const params = {
-        org:                KUBEWARDEN_PRODUCT_NAME, // Limit to the Kubewarden organization
         kind:               13, // Kind for Kubewarden policies
-        verified_publisher: true, // Require verified publisher
-        official:           true, // Ensure package is official
         limit:              50 // limit to 50, default is 20
       };
 

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -10,7 +10,7 @@ import { CONFIG_MAP, MANAGEMENT, SERVICE } from '@shell/config/types';
 import { findBy, isArray } from '@shell/utils/array';
 import { addParams } from '@shell/utils/url';
 
-import { KUBEWARDEN, KUBEWARDEN_PRODUCT_NAME, METRICS_DASHBOARD } from '../types';
+import { KUBEWARDEN, METRICS_DASHBOARD } from '../types';
 import policyServerDashboard from '../assets/kubewarden-metrics-policyserver.json';
 import policyDashboard from '../assets/kubewarden-metrics-policy.json';
 

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -1,0 +1,128 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import PolicyGrid from '@kubewarden/components/Policies/PolicyGrid.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+
+import policyPackages from '../../templates/policyPackages.js';
+
+describe('component: General', () => {
+  it('should render custom card when provided empty packages', () => {
+    const packages: Array<any> = [];
+    const customSubtype = `<div>Custom Policy</div>`;
+
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { targetNamespace: 'default', value: packages },
+      mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } },
+      slots:     { customSubtype }
+    });
+
+    expect(wrapper.html()).toContain('Custom Policy');
+  });
+
+  it('should render provided packages', () => {
+    const customSubtype = `<div>Custom Policy</div>`;
+
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } },
+      slots:      { customSubtype }
+    });
+
+    expect(wrapper.html()).toContain('Custom Policy');
+    expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+  });
+
+  it('should render correct provider options in LabeledSelect', () => {
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    const selects = wrapper.findAllComponents(LabeledSelect);
+
+    expect(selects.at(0).props().options).toStrictEqual(['kubewarden', 'evil'] as String[]);
+  });
+
+  it('filters shown cards by provider when selected', async() => {
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+    expect(wrapper.html()).toContain('Signed Test Policy');
+    expect(wrapper.html()).toContain('Test Policy 2');
+
+    await wrapper.setData({ provider: ['evil'] });
+
+    expect(wrapper.html()).not.toContain('Allow Privilege Escalation PSP');
+    expect(wrapper.html()).toContain('Test Policy 2');
+  });
+
+  it('should render correct keyword options in LabeledSelect', () => {
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } },
+    });
+
+    const selects = wrapper.findAllComponents(LabeledSelect);
+
+    expect(selects.at(1).props().options).toStrictEqual(['PSP', 'privilege escalation'] as String[]);
+  });
+
+  it('filters shown cards by keywords when selected', async() => {
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+    expect(wrapper.html()).toContain('Signed Test Policy');
+    expect(wrapper.html()).toContain('Test Policy 2');
+
+    await wrapper.setData({ keywords: ['PSP'] });
+
+    expect(wrapper.html()).not.toContain('Signed Test Policy');
+    expect(wrapper.html()).toContain('Test Policy 2');
+  });
+
+  it('should render correct resource options in LabeledSelect', () => {
+    const options: String[] = ['Deployment', 'Replicaset', 'Statefulset', 'Daemonset', 'Replicationcontroller', 'Job', 'Cronjob', 'Pod'];
+
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    const selects = wrapper.findAllComponents(LabeledSelect);
+
+    expect(selects.at(2).props().options).toStrictEqual(options as String[]);
+  });
+
+  it('filters shown cards by resources when selected', async() => {
+    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+    expect(wrapper.html()).toContain('Signed Test Policy');
+    expect(wrapper.html()).toContain('Test Policy 2');
+
+    await wrapper.setData({ category: ['Daemonset'] });
+
+    expect(wrapper.html()).not.toContain('Signed Test Policy');
+    expect(wrapper.html()).toContain('Test Policy 2');
+    expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+  });
+});

--- a/tests/unit/templates/policyPackages.js
+++ b/tests/unit/templates/policyPackages.js
@@ -1,0 +1,32 @@
+export default [
+  {
+    name:         'allow-privilege-escalation-psp',
+    display_name: 'Allow Privilege Escalation PSP',
+    description:  'Replacement for the Kubernetes Pod Security Policy that controls the allowance of privilege escalation in containers and init containers of a pod',
+    keywords:     ['PSP', 'privilege escalation'],
+    data:         { 'kubewarden/resources': 'Deployment,Replicaset,Statefulset,Daemonset,Replicationcontroller,Job,Cronjob,Pod' },
+    signed:       true,
+    signatures:   ['cosign'],
+    provider:     'kubewarden'
+  },
+  {
+    name:         'signed-test-policy',
+    display_name: 'Signed Test Policy',
+    description:  'A signed test policy with no signatures',
+    signed:       true,
+    provider:     'evil'
+  },
+  {
+    name:         'test-policy',
+    display_name: 'Test Policy',
+    description:  'A test policy with no info'
+  },
+  {
+    name:         'test-policy-2',
+    display_name: 'Test Policy 2',
+    description:  'A test policy with less info',
+    data:         { 'kubewarden/resources': 'Daemonset' },
+    keywords:     ['PSP'],
+    provider:     'evil'
+  }
+];


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #229 

This adds filtering by providers (organization name) for policies fetched from ArtifactHub. A "Kubewarden" badge will be placed next to the signed icon if it is an official Kubewarden package (from the Kubewarden organization).

Removed the queries from artifacthub fetching to include all policies regardless of organization.

![badge](https://user-images.githubusercontent.com/40806497/234073331-0a9f3b71-641a-4bdd-aa6b-97c4b5e8765c.png)

