### PR TITLE
Remove metrics env from policy server default spec

### DIFF
--- a/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.policyserver.js
@@ -11,7 +11,6 @@ export const DEFAULT_POLICY_SERVER = {
   spec:       {
     annotations: {},
     env:         [
-      { name: 'KUBEWARDEN_ENABLE_METRICS', value: '1' },
       { name: 'KUBEWARDEN_LOG_FMT', value: 'otlp' },
       { name: 'KUBEWARDEN_LOG_LEVEL', value: 'info' }
     ],


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #337 

This removes the `KUBEWARDEN_ENABLE_METRICS` environment variable from the default Policy Server spec, which is used in creation of a custom policy server.