### PR TITLE
Rancher rc is broken, use released version

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -90,6 +90,9 @@ jobs:
         echo KUBEWARDEN=$KUBEWARDEN | tee -a $GITHUB_ENV
         echo TESTSUITE="$TESTSUITE" | tee -a $GITHUB_ENV
 
+        # Rancher v2.7.5-rc2 is broken, use released one
+        echo RANCHER=released | tee -a $GITHUB_ENV
+
     # ==================================================================================================
     # Create k3d cluster and install rancher
     - name: "Create kubernetes cluster"


### PR DESCRIPTION
Temporary overwrite `rc` option.

We need to figure out how to test on rancher rc-s (to make sure kubewarden will work when they release new rancher) while taking into account that rancher-rc builds can be broken.

Fix for https://github.com/kubewarden/ui/actions/runs/5063992137/jobs/9091148586