### PR TITLE
Add functionality to remove subquestion properties after enum updates

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -479,6 +479,12 @@ $color: var(--body-text) !important;
 }
 
 ::v-deep .controls-row {
+  position: sticky;
+  bottom: 0;
+  background: var(--body-bg);
+  margin-top: 24px;
+  z-index: 100;
+
   .controls-steps {
     display: flex;
   }

--- a/pkg/kubewarden/components/Questions/Enum.vue
+++ b/pkg/kubewarden/components/Questions/Enum.vue
@@ -1,0 +1,38 @@
+<script>
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import Question from './Question';
+
+export default {
+  components: { LabeledSelect },
+  mixins:     [Question],
+  methods:    {
+    update($event) {
+      this.$emit('enumUpdate', $event);
+      this.$emit('input', $event);
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="row">
+    <div class="col span-6">
+      <LabeledSelect
+        :mode="mode"
+        :label="displayLabel"
+        :options="question.options"
+        :placeholder="question.description"
+        :required="question.required"
+        :value="value"
+        :disabled="disabled"
+        @input="update($event)"
+      />
+    </div>
+    <div
+      v-if="showDescription"
+      class="col span-6 mt-10"
+    >
+      {{ displayDescription }}
+    </div>
+  </div>
+</template>

--- a/pkg/kubewarden/components/Questions/tmp.json
+++ b/pkg/kubewarden/components/Questions/tmp.json
@@ -1,0 +1,55 @@
+[
+  {
+    "default": "",
+    "group": "Settings",
+    "label": "Rule",
+    "options": [
+      "MustRunAs",
+      "MustRunAsNonRoot",
+      "RunAsAny"
+    ],
+    "type": "enum",
+    "variable": "run_as_user.rule",
+    "depth": 2
+  },
+  {
+    "default": false,
+    "group": "Settings",
+    "label": "Overwrite",
+    "show_if": "run_as_user.rule=MustRunAs",
+    "title": "Overwrite",
+    "type": "boolean",
+    "variable": "run_as_user.overwrite",
+    "depth": 2
+  },
+  {
+    "default": [],
+    "group": "Settings",
+    "label": "Ranges",
+    "show_if": "run_as_user.rule=MustRunAs||run_as_user.rule=MustRunAsNonRoot",
+    "hide_input": true,
+    "type": "sequence[",
+    "variable": "run_as_user.ranges",
+    "sequence_questions": [
+      {
+        "default": 0,
+        "group": "Settings",
+        "label": "min",
+        "show_if": "run_as_user.rule=MustRunAs||run_as_user.rule=MustRunAsNonRoot",
+        "tooltip": "Minimum UID or GID",
+        "type": "int",
+        "variable": "min"
+      },
+      {
+        "default": 0,
+        "group": "Settings",
+        "label": "max",
+        "show_if": "run_as_user.rule=MustRunAs||run_as_user.rule=MustRunAsNonRoot",
+        "tooltip": "Maxium UID or GID",
+        "type": "int",
+        "variable": "max"
+      }
+    ],
+    "depth": 2
+  }
+]

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -474,23 +474,37 @@ export default class KubewardenModel extends SteveModel {
     if (remove && whitelistValue.includes(url)) {
       const out = whitelistValue.filter(domain => domain !== url);
 
-      whitelist.default = out.join();
       whitelist.value = out.join();
 
       try {
         return whitelist.save();
-      } catch (e) {}
+      } catch (e) {
+        const error = e?.data || e;
+
+        this.$dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 5000,
+        }, { root: true });
+      }
     }
 
     if (!whitelistValue.includes(url)) {
       whitelistValue.push(url);
 
-      whitelist.default = whitelistValue.join();
       whitelist.value = whitelistValue.join();
 
       try {
         return whitelist.save();
-      } catch (e) {}
+      } catch (e) {
+        const error = e?.data || e;
+
+        this.$dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 5000,
+        }, { root: true });
+      }
     }
   }
 }

--- a/pkg/kubewarden/utils/handle-growl.ts
+++ b/pkg/kubewarden/utils/handle-growl.ts
@@ -7,7 +7,7 @@ interface GrowlConfig {
     _statusText: String,
     message: String
   },
-  store: any
+  store?: any
 }
 
 export function handleGrowlError(config: GrowlConfig): void {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #297 

This issue was caused by Enum types in questions not removing subquestion properties when the value changes. The fix is to delete the keys from the main value when an update is emitted by an Enum question type.


https://github.com/kubewarden/ui/assets/40806497/b60f0c12-b549-4d81-a0e4-556224ebf8ba


