### PR TITLE
Add check for map type questions with undefined group

### DIFF
--- a/pkg/kubewarden/components/Questions/index.vue
+++ b/pkg/kubewarden/components/Questions/index.vue
@@ -232,6 +232,12 @@ export default {
       let weight = this.shownQuestions.length;
 
       for ( const q of this.shownQuestions ) {
+        if ( q.type?.startsWith('map[') && q.group === undefined ) {
+          const subWithGroup = q.subquestions.find(sub => sub.group);
+
+          q.group = subWithGroup.group;
+        }
+
         const group = q.group || defaultGroup;
 
         const normalized = group.trim().toLowerCase();


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #362 

The issue was caused by the psa-label-enforcer questions for the `map[` type not containing [a defined `group`](https://github.com/kubewarden/psa-label-enforcer-policy/blob/afdd4355ca7c65dbcc12fdf667d1397d63037ac8/questions-ui.yml#L11-L18), but each subsequent `subquestions` containing a specified `group`. 

This fixes the issue by adding a check for `map[` types with an undefined `group`, then searching the subquestions for a group to apply.

![psa-label-enforcer](https://github.com/kubewarden/ui/assets/40806497/435f9eae-bf24-49b9-80fe-6aeb7fafa152)

#### Alternative
Ultimately, all `map[` type questions should have a group defined that is the same as the group defined for each of it's subequestions. But this fix will at least account for issues where the group is missed. 
