### PR TITLE
Add context aware to policy config

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
@@ -1,0 +1,155 @@
+<script>
+import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
+
+import { _CREATE } from '@shell/config/query-params';
+import { SCHEMA } from '@shell/config/types';
+
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+
+import * as coreTypes from '../../../../core/core-resources';
+
+export default {
+  name: 'Resource',
+
+  props: {
+    /** Every groupVersion from apiGroups */
+    apiGroupVersions: {
+      type:     Array,
+      required: true
+    },
+
+    disabled: {
+      type:     Boolean,
+      required: true
+    },
+
+    mode: {
+      type:    String,
+      default: _CREATE
+    },
+
+    value: {
+      type:    Object,
+      default: () => {}
+    }
+  },
+
+  components: { LabeledSelect },
+
+  watch: { 'value.apiVersion': 'clearKind' },
+
+  computed: {
+    ...mapGetters(['currentProduct']),
+
+    allSchemas() {
+      return this.$store.getters[`${ this.currentProduct.inStore }/all`](SCHEMA);
+    },
+
+    isCreate() {
+      return this.mode === _CREATE;
+    },
+
+    apiVersionOptions() {
+      const out = [];
+
+      if ( !isEmpty(this.apiGroupVersions) ) {
+        this.apiGroupVersions.forEach(group => out.push(group.groupVersion));
+      }
+
+      return out;
+    },
+
+    /** Find the matching schema to the group and return the availble Kinds */
+    kindOptions() {
+      const kindSchema = [];
+
+      if ( this.value?.apiVersion ) {
+        const matchedGroup = this.apiGroupVersions.find(group => this.value.apiVersion === group.groupVersion);
+        const matchedSchemas = this.schemaForGroup(matchedGroup);
+
+        if ( !isEmpty(matchedSchemas) ) {
+          matchedSchemas.forEach(schema => kindSchema.push(schema.attributes?.kind));
+        }
+      }
+
+      return kindSchema;
+    }
+  },
+
+  methods: {
+    clearKind() {
+      if ( !isEmpty(this.value.kind) ) {
+        this.$set(this.value, 'kind', null);
+      }
+    },
+
+    schemaForGroup(group) {
+      if ( !!group ) {
+        /**
+         * If the 'core' group is selected, the Steve api does not have a mechanism to return only
+         * the legacy resources that fall under 'core'. They appear in the schemas as having an
+         * empty group... but there are **many** schemas that have an empty group, so they have
+         * been declared in `./core/core.d.ts` to have a bonified list of core resources.
+         */
+        if ( group.groupName === 'core' ) {
+          const types = Object.values(coreTypes);
+
+          return types;
+        }
+
+        return this.allSchemas?.filter(s => s._group === group.groupName);
+      }
+
+      return null;
+    },
+  }
+};
+</script>
+
+<template>
+  <div
+    v-if="value"
+    class="resource-row mt-40 mb-20"
+  >
+    <div class="col span-4">
+      <LabeledSelect
+        v-model="value.apiVersion"
+        :disabled="disabled"
+        :clearable="false"
+        :searchable="true"
+        :mode="mode"
+        :multiple="false"
+        :options="apiVersionOptions"
+        placement="bottom"
+        :label="t('kubewarden.policyConfig.contextAware.resource.apiVersion.label')"
+        :tooltip="t('kubewarden.policyConfig.contextAware.resource.apiVersion.tooltip')"
+      />
+    </div>
+
+    <div class="col span-4">
+      <LabeledSelect
+        v-model="value.kind"
+        :disabled="disabled"
+        :clearable="false"
+        :searchable="true"
+        :mode="mode"
+        :multiple="false"
+        :options="kindOptions"
+        placement="bottom"
+        :label="t('kubewarden.policyConfig.contextAware.resource.kind.label')"
+        :tooltip="t('kubewarden.policyConfig.contextAware.resource.kind.tooltip')"
+      />
+    </div>
+
+    <slot name="removeResource" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.resource-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+</style>

--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
@@ -1,0 +1,122 @@
+<script>
+import { mapGetters } from 'vuex';
+import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { removeAt } from '@shell/utils/array';
+
+import { Banner } from '@components/Banner';
+import Loading from '@shell/components/Loading';
+
+import { isEmpty } from '@shell/utils/object';
+import { KUBEWARDEN_APPS } from '../../../../types';
+import { ARTIFACTHUB_PKG_ANNOTATION } from '../../../../plugins/kubewarden-class';
+import Resource from './Resource';
+
+export default {
+  name: 'ContextAware',
+
+  props: {
+    mode: {
+      type:    String,
+      default: _CREATE
+    },
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  components: {
+    Banner, Loading, Resource
+  },
+
+  async fetch() {
+    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: 'apigroup' });
+
+    this.contextAwareResources = [];
+
+    if ( !!this.value?.policy ) {
+      this.contextAwareResources = this.value.policy?.spec?.contextAwareResources;
+    }
+  },
+
+  data() {
+    return { contextAwareResources: null };
+  },
+
+  computed: {
+    ...mapGetters(['currentProduct']),
+
+    apiGroups() {
+      return this.$store.getters[`${ this.currentProduct.inStore }/all`]('apigroup');
+    },
+
+    /** Return the group ID and groupVersion for each apiGroup */
+    apiGroupVersions() {
+      const out = [];
+
+      if ( !isEmpty(this.apiGroups) ) {
+        this.apiGroups.forEach((group) => {
+          for ( const version of group.versions ) {
+            out.push({ groupName: group.id, groupVersion: version?.groupVersion });
+          }
+        });
+      }
+
+      return [...new Set(out)];
+    },
+
+    /** Determines if the policy originates from ArtifactHub or the kubewarden-defaults chart */
+    disabledcontextAwareResources() {
+      const annotations = this.value.policy?.metadata?.annotations;
+
+      return !!annotations?.[ARTIFACTHUB_PKG_ANNOTATION] || annotations?.['meta.helm.sh/release-name'] === KUBEWARDEN_APPS.RANCHER_DEFAULTS;
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+  },
+
+  methods: {
+    addResource() {
+      this.contextAwareResources.push({});
+    },
+
+    removeResource(index) {
+      removeAt(this.contextAwareResources, index);
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" mode="relative" />
+  <div v-else>
+    <p>{{ t('kubewarden.policyConfig.contextAware.description') }}</p>
+    <Banner
+      class="mb-20"
+      color="warning"
+      :label="t('kubewarden.policyConfig.contextAware.warning')"
+    />
+
+    <div v-for="(resource, index) in contextAwareResources" :key="'filtered-resource-' + index">
+      <Resource
+        ref="lastResource"
+        v-model="contextAwareResources[index]"
+        :disabled="disabledcontextAwareResources"
+        :mode="mode"
+        :api-group-versions="apiGroupVersions"
+      >
+        <template v-if="!isView && !disabledcontextAwareResources" #removeResource>
+          <button type="button" class="btn role-link p-0" @click="removeResource(index)">
+            {{ t('kubewarden.policyConfig.contextAware.resource.remove') }}
+          </button>
+        </template>
+      </Resource>
+    </div>
+
+    <button v-if="!isView && !disabledcontextAwareResources" type="button" class="btn role-tertiary add" @click="addResource">
+      {{ t('kubewarden.policyConfig.contextAware.resource.add') }}
+    </button>
+  </div>
+</template>

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
@@ -8,7 +8,7 @@ import { SCHEMA } from '@shell/config/types';
 
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 
-import { KUBEWARDEN } from '../../../types';
+import { KUBEWARDEN } from '../../../../types';
 
 export default {
   name: 'Rule',

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
@@ -5,8 +5,8 @@ import { removeAt } from '@shell/utils/array';
 
 import Loading from '@shell/components/Loading';
 
-import { KUBEWARDEN_APPS } from '../../../types';
-import { ARTIFACTHUB_PKG_ANNOTATION } from '../../../plugins/kubewarden-class';
+import { KUBEWARDEN_APPS } from '../../../../types';
+import { ARTIFACTHUB_PKG_ANNOTATION } from '../../../../plugins/kubewarden-class';
 import Rule from './Rule';
 
 export default {

--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -10,7 +10,8 @@ import Tab from '@shell/components/Tabbed/Tab';
 import Questions from '../../../components/Questions';
 import General from './General';
 import Rules from './Rules';
-import Settings from './Settings.vue';
+import Settings from './Settings';
+import ContextAware from './ContextAware';
 
 export default {
   props: {
@@ -29,7 +30,7 @@ export default {
   },
 
   components: {
-    General, Questions, Rules, Settings, Tab
+    General, Questions, Rules, Settings, ContextAware, Tab
   },
 
   data() {
@@ -43,16 +44,16 @@ export default {
   },
 
   computed: {
+    hasContextAware() {
+      return !isEmpty(this.value?.policy?.spec?.contextAwareResources);
+    },
+
     hasSettings() {
       return !isEmpty(this.value?.policy?.spec?.settings);
     },
 
     hasQuestions() {
-      if ( !isEmpty(this.chartValues?.questions?.questions) ) {
-        return true;
-      }
-
-      return false;
+      return !isEmpty(this.chartValues?.questions?.questions);
     },
 
     isCreate() {
@@ -61,6 +62,10 @@ export default {
 
     isCustom() {
       return this.customPolicy;
+    },
+
+    showContextAware() {
+      return this.hasContextAware || this.isCustom;
     },
 
     showSettings() {
@@ -96,15 +101,21 @@ export default {
 
 <template>
   <div>
-    <Tab name="general" label="General" :weight="99">
+    <Tab name="general" :label="t('kubewarden.policyConfig.tabs.general')" :weight="99">
       <General v-model="chartValues" :mode="mode" :target-namespace="targetNamespace" />
     </Tab>
-    <Tab name="rules" label="Rules" :weight="98">
+    <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="98">
       <Rules v-model="chartValues" :mode="mode" />
     </Tab>
 
+    <template v-if="showContextAware">
+      <Tab name="contextAware" :label="t('kubewarden.policyConfig.tabs.contextAware')" :weight="97">
+        <ContextAware v-model="chartValues" :mode="mode" />
+      </Tab>
+    </template>
+
     <template v-if="showSettings">
-      <Tab name="settings" label="Settings" :weight="97">
+      <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="96">
         <Settings
           v-model="chartValues"
           @updateSettings="settingsChanged($event)"
@@ -114,7 +125,7 @@ export default {
 
     <!-- Values as questions -->
     <template v-if="hasQuestions">
-      <Tab name="Settings" label="Settings" :weight="97">
+      <Tab name="Settings" label="Settings" :weight="96">
         <Questions
           v-model="chartValues.policy.spec.settings"
           :mode="mode"

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -272,9 +272,9 @@ export default {
             </span>
           </div>
 
-          <div v-if="hasAnnotation(subtype, 'kubewarden/contextAware')" class="subtype__aware">
-            <span>
-              {{ t('kubewarden.policyCharts.contextAware') }}
+          <div v-if="hasAnnotation(subtype, 'kubewarden/contextAwareResources')" class="subtype__aware">
+            <span v-tooltip="t('kubewarden.policyCharts.contextAware.tooltip')">
+              {{ t('kubewarden.policyCharts.contextAware.label') }}
             </span>
           </div>
 
@@ -430,7 +430,7 @@ $margin: 10px;
   }
 
   &__aware {
-    right: 30px;
+    right: 80px;
   }
 
   &__icon {

--- a/pkg/kubewarden/core/core-resources.ts
+++ b/pkg/kubewarden/core/core-resources.ts
@@ -1,0 +1,101 @@
+import * as core from 'core';
+
+export const pod: core.Pod = {
+  id:         'pod',
+  attributes: {
+    group:      'core',
+    kind:       'Pod',
+    resource:   'pods',
+    namespaced: true
+  }
+};
+
+export const service: core.Service = {
+  id:         'service',
+  attributes: {
+    group:      'core',
+    kind:       'Service',
+    resource:   'services',
+    namespaced: true
+  }
+};
+
+export const replicationController: core.ReplicationController = {
+  id:         'replicationcontroller',
+  attributes: {
+    group:      'core',
+    kind:       'ReplicationController',
+    resource:   'replicationcontrollers',
+    namespaced: true
+  }
+};
+
+export const secret: core.Secret = {
+  id:         'secret',
+  attributes: {
+    group:      'core',
+    kind:       'Secret',
+    resource:   'secrets',
+    namespaced: true
+  }
+};
+
+export const configMap: core.ConfigMap = {
+  id:         'configmap',
+  attributes: {
+    group:      'core',
+    kind:       'ConfigMap',
+    resource:   'configmaps',
+    namespaced: true
+  }
+};
+
+export const namespace: core.Namespace = {
+  id:         'namespace',
+  attributes: {
+    group:      'core',
+    kind:       'Namespace',
+    resource:   'namespaces',
+    namespaced: false
+  }
+};
+
+export const event: core.Event = {
+  id:         'event',
+  attributes: {
+    group:      'core',
+    kind:       'Event',
+    resource:   'events',
+    namespaced: true
+  }
+};
+
+export const node: core.Node = {
+  id:         'node',
+  attributes: {
+    group:      'core',
+    kind:       'Node',
+    resource:   'nodes',
+    namespaced: false
+  }
+};
+
+export const persistentVolume: core.PersistentVolume = {
+  id:         'persistentvolume',
+  attributes: {
+    group:      'core',
+    kind:       'PersistentVolume',
+    resource:   'persistentvolumes',
+    namespaced: false
+  }
+};
+
+export const persistentVolumeClaim: core.PersistentVolumeClaim = {
+  id:         'persistentvolumeclaim',
+  attributes: {
+    group:      'core',
+    kind:       'PersistentVolumeClaim',
+    resource:   'persistentvolumeclaims',
+    namespaced: true
+  }
+};

--- a/pkg/kubewarden/core/core.d.ts
+++ b/pkg/kubewarden/core/core.d.ts
@@ -1,0 +1,22 @@
+declare module 'core' {
+  type CoreResource = {
+    id: string;
+    attributes: {
+      group: string;
+      kind: string;
+      resource: string;
+      namespaced: boolean;
+    }
+  };
+
+  export interface Pod extends CoreResource {}
+  export interface Service extends CoreResource {}
+  export interface ReplicationController extends CoreResource {}
+  export interface Secret extends CoreResource {}
+  export interface ConfigMap extends CoreResource {}
+  export interface Namespace extends CoreResource {}
+  export interface Event extends CoreResource {}
+  export interface Node extends CoreResource {}
+  export interface PersistentVolume extends CoreResource {}
+  export interface PersistentVolumeClaim extends CoreResource {}
+}

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -132,6 +132,11 @@ kubewarden:
     noService: The Metrics service is not currently active or is not installed correctly. Check the status of the Monitoring app.
 
   policyConfig:
+    tabs:
+      general: General
+      rules: Rules
+      settings: Settings
+      contextAware: Context Aware Resources
     serverSelect:
       label: Policy Server
       tooltip: The PolicyServer that will receive the requests to be validated.
@@ -170,6 +175,20 @@ kubewarden:
     scope:
       label: Scope
       tooltip: Specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "". "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+    contextAware:
+      label: Context Aware Resources
+      description: A list of Kubernetes resources the policy is allowed to access at evaluation time. Access to these resources is done using the ServiceAccount of the PolicyServer the policy is assigned to.
+      warning: >-
+        Kubewarden administrators need to thoroughly examine the types of resources that a policy will access in order to prevent any misuse or abuse of the system. In some cases, it may be necessary to increase the permissions of the ServiceAccount associated with the PolicyServer to enable the policy to retrieve the required information. Although policies are restricted to read-only access to Kubernetes resources, there is a risk that a malicious attacker could exploit a Kubewarden policy to extract sensitive data from the cluster.
+      resource:
+        add: Add Resource
+        remove: Remove Resource
+        apiVersion:
+          label: API Version
+          tooltip: This is the apiVersion of the resource (v1 for core group, groupName/groupVersions for other).
+        kind:
+          label: Kind
+          tooltip: Singular PascalCase name of the resource
   policyServerConfig:
     defaultImage:
       label: Default Image
@@ -204,8 +223,10 @@ kubewarden:
       tooltip: This policy has been signed with { signatures }.
     mutationPolicy:
       label: Mutation
-      tooltip: Mutation Policy
-    contextAware: Context Aware
+      tooltip: A mutating policy will rebuild the requests with definied values that are conformant with the policy definition.
+    contextAware: 
+      label: Context Aware
+      tooltip: Can determine whether an AdmissionRequest has to be accepted or rejected based on other resources already deployed in the cluster.
 
 asyncButton:
   artifactHub:

--- a/pkg/kubewarden/plugins/policy-class.js
+++ b/pkg/kubewarden/plugins/policy-class.js
@@ -21,7 +21,6 @@ export const DEFAULT_POLICY = {
       resources:   [],
       operations:  []
     }],
-    contextAware: false,
     mutating:     false,
     settings:     {}
   }
@@ -73,9 +72,9 @@ export default class PolicyModel extends KubewardenModel {
     return stateBackground();
   }
 
-  /*
-    If a the policy is from ArtifactHub we need to fetch the questions that correspond to the
-    version of the policy. This is saved as an annotation on the policy.
+  /**
+   * If a the policy is from ArtifactHub we need to fetch the questions that correspond to the
+   * version of the policy. This is saved as an annotation on the policy.
   */
   get artifactHubPackageVersion() {
     return () => {
@@ -97,6 +96,7 @@ export default class PolicyModel extends KubewardenModel {
     };
   }
 
+  /** Parse provided yaml into workable json - returns js object */
   parsePackageMetadata(data) {
     if ( data ) {
       const parsed = JSON.parse(JSON.stringify(data));

--- a/pkg/kubewarden/tsconfig.json
+++ b/pkg/kubewarden/tsconfig.json
@@ -15,7 +15,8 @@
     "preserveSymlinks": true,
     "typeRoots": [
       "../../node_modules",
-      "../../node_modules/@rancher/shell/types"
+      "../../node_modules/@rancher/shell/types",
+      "./core"
     ],
     "types": [
       "node",
@@ -23,7 +24,8 @@
       "@types/lodash",
       "@nuxt/types",
       "rancher",
-      "shell"
+      "shell",
+      "core"
     ],
     "lib": [
       "esnext",

--- a/tests/unit/charts/admission/Rules.spec.ts
+++ b/tests/unit/charts/admission/Rules.spec.ts
@@ -3,8 +3,8 @@ import { DefaultProps } from 'vue/types/options';
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
-import Rules from '@kubewarden/chart/kubewarden/admission/Rules.vue';
-import Rule from '@kubewarden/chart/kubewarden/admission/Rule.vue';
+import Rules from '@kubewarden/chart/kubewarden/admission/Rules';
+import Rule from '@kubewarden/chart/kubewarden/admission/Rules/Rule.vue';
 
 import policyConfig from '../../templates/policyConfig';
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #388 

This adds the correct annotation to search for `contextAwareResources` from a policy's metadata. With the addition of this spec, I have added a tab to declare/view context aware resources for policies which contain this annotation or for custom policies.
Also fixed the badge on the policy grid page to show context aware policies

___Namespace label propagator context___
![namespace-label-context](https://github.com/kubewarden/ui/assets/40806497/40a725de-2e65-4a8e-a1c1-1820e7f96f50)

___Custom policy context___
![custom-context](https://github.com/kubewarden/ui/assets/40806497/ba819a8c-4faf-44f6-a443-9084a32df4d6)

___Policy grid Context Aware badge___
![badge](https://github.com/kubewarden/ui/assets/40806497/3fe28404-a709-455b-a5f6-f8d0cf79ab8f)

