### PR TITLE
Fix order of namespaceSelector addition to policy spec

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -242,17 +242,18 @@ export default ({
     async finish(event) {
       try {
         let out;
-        const { ignoreRancherNamespaces } = this.chartValues.policy;
-
-        if ( ignoreRancherNamespaces ) {
-          set(this.chartValues.policy.spec, 'namespaceSelector', { matchExpressions: [NAMESPACE_SELECTOR] });
-          delete this.chartValues.policy.ignoreRancherNamespaces;
-        }
 
         if ( this.yamlOption === VALUES_STATE.YAML ) {
           out = jsyaml.load(this.yamlValues);
         } else {
           out = this.chartValues?.policy ? this.chartValues.policy : jsyaml.load(this.yamlValues);
+        }
+
+        const { ignoreRancherNamespaces } = out;
+
+        if ( ignoreRancherNamespaces ) {
+          set(out.spec, 'namespaceSelector', { matchExpressions: [NAMESPACE_SELECTOR] });
+          delete out.ignoreRancherNamespaces;
         }
 
         removeEmptyAttrs(out); // Clean up empty values from questions


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #399 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This fixes the order in which the `namespaceSelector` property is added to a policy upon creation. When creating from the yaml editor the statement to apply the Rancher namespaces was being overwritten when the yaml was parsed and merged into the final output.

## Test

- deploy v2.7.5-rc5 rancher, 1.0.5 kubewarden UI, k3d -> k3s v1.25.8 +k3s1
- enable default policy server + recommended policies in monitor mode
- add namespace label propagator policy
  - Ignore rancher namespaces: true
  - Mode: protect
  - Settings -> Add label -> `foo`
  - Go to `Edit YAML` tab and create the policy
- View the new policy's yaml to ensure the `namespaceSelector` property has been added 



https://github.com/kubewarden/ui/assets/40806497/d25f9df6-8562-4961-979c-3c9ad275ab41

