### PR TITLE
Fix PolicyServer related policies table to show flat list

### DIFF
--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -7,6 +7,7 @@ import { monitoringStatus } from '@shell/utils/monitoring';
 import { dashboardExists } from '@shell/utils/grafana';
 import { allHash } from '@shell/utils/promise';
 import CreateEditView from '@shell/mixins/create-edit-view';
+import { mapPref, GROUP_RESOURCES } from '@shell/store/prefs';
 
 import { Banner } from '@components/Banner';
 import CountGauge from '@shell/components/CountGauge';
@@ -127,9 +128,16 @@ export default {
   computed: {
     ...mapGetters(['currentCluster', 'currentProduct']),
     ...monitoringStatus(),
+    _group: mapPref(GROUP_RESOURCES),
 
     emptyTraces() {
       return isEmpty(this.filteredValidations);
+    },
+
+    groupPreference() {
+      const out = this._group === 'namespace' ? 'kind' : null;
+
+      return out;
     },
 
     relatedPoliciesTotal() {
@@ -220,7 +228,7 @@ export default {
             :rows="relatedPolicies || []"
             :headers="RELATED_HEADERS"
             :groupable="true"
-            group-by="kind"
+            :group-by="groupPreference"
             :table-actions="true"
           >
             <template #col:operation="{ row }">

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -97,6 +97,8 @@ kubewarden:
     policyGauge:
       byStatus: Policies by Status
       traces: Policy Validations
+    groups:
+      kind: Policy Type
   admissionPolicy:
     title: Admission Policies
     description: AdmissionPolicy is a namespace-wide resource. These policies will process only the requests that are targeting the Namespace where the AdmissionPolicy is defined.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #363 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
This will fix the issue of the "Flat List" button not updating the grouping of the resource table.

___Grouping by policy kind___
![kind](https://github.com/kubewarden/ui/assets/40806497/0126b39e-1e14-4b5f-9352-51cc441240b2)


___Flat list___
![flat](https://github.com/kubewarden/ui/assets/40806497/8b949ed6-657a-43de-bb0a-c87ebe0c2967)
