### PR TITLE
Add Cluster Admission Policies test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Install Kubewarden
       working-directory: tests
       run: |
-        yarn playwright test installation overview -x
+        yarn playwright test installation overview policyservers -x
       env:
         RANCHER_URL: https://${{env.RANCHER_FQDN}}
         ORIGIN: ${{ env.KUBEWARDEN }}

--- a/tests/e2e/clusteradmissionpolicies.spec.ts
+++ b/tests/e2e/clusteradmissionpolicies.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from './rancher-test';
+import { PolicyServersPage } from './pages/policyservers.page';
+import { ClusterAdmissionPoliciesPage } from './pages/clusteradmissionpolicies.page';
+import { Policy } from './pages/basepolicypage';
+import { TableRow } from './components/table-row';
+
+test('ClusterAdmissionPolicies ', async({ page, ui }) => {
+  const pName = 'test-policy-podpriv'
+  const p: Policy = {title: 'Pod Privileged Policy'}
+
+  const capPage = new ClusterAdmissionPoliciesPage(page)
+
+  const finishBtn = page.getByRole('button', { name: 'Finish', exact: true })
+
+  let row: TableRow
+
+  // ====================================================================================
+  // Creation without required fields
+  await capPage.goto()
+  await capPage.open(p)
+  // Try to create without name
+  await capPage.setName('')
+  await finishBtn.click()
+  await expect(page.locator('div.error').getByText('Required value: name')).toBeVisible()
+  await finishBtn.waitFor({timeout: 10_000}) // button name changes back Error -> Finish
+  // Try without module
+  await capPage.setValues({title: p.title, name: pName, module: ''})
+  await expect(finishBtn).not.toBeEnabled()
+
+  // ====================================================================================
+  // Try monitor & protect mode
+  await capPage.goto()
+  // Create in protect
+  row = await capPage.create({title: p.title, name: 'test-policy-mode-protect', mode: 'Protect'}, {wait: true})
+  await expect(row.column('Mode')).toHaveText('Protect')
+  await row.delete()
+  // Create in monitor, change to protect, can't change back
+  row = await capPage.create({title: p.title, name: 'test-policy-mode-monitor', mode: 'Monitor'}, {wait: true})
+
+  await expect(row.column('Mode')).toHaveText('Monitor')
+  await capPage.updateToProtect(row)
+  await expect(row.column('Mode')).toHaveText('Protect')
+  await row.delete()
+
+  // ====================================================================================
+  // Try default & custom policy server
+
+  let customPS = 'test-cap-custom-ps'
+
+  // Create custom policy server
+  const psPage = new PolicyServersPage(page)
+  await psPage.goto()
+  await psPage.create(customPS, {wait: true})
+
+  // Create policy with custom PS
+  await capPage.goto()
+  row = await capPage.create({title: p.title, name: 'test-policy-custom-ps', server: customPS}, {wait: true})
+  await expect(row.column('Policy Server')).toHaveText(customPS)
+  // Delete custom PS, check policy is deleted too
+  await psPage.goto()
+  await psPage.delete(customPS)
+  await capPage.goto()
+  await expect(row.row).not.toBeVisible()
+
+  // Create policy with default PS
+  await capPage.goto()
+  row = await capPage.create({title: p.title, name: 'test-policy-default-ps'})
+  await expect(row.column('Policy Server')).toHaveText('default')
+  // Check details page
+  await row.open()
+  await expect(page.getByText('ClusterAdmissionPolicy: test-policy-default-ps')).toBeVisible()
+  await expect(page.getByText('API Versions')).toBeVisible()
+  // Check config page
+  await page.locator('div.actions-container').getByRole('button', {name: 'Config', exact: true}).click()
+  await expect(ui.input('Name*')).toHaveValue('test-policy-default-ps')
+  await capPage.goto()
+  await row.delete()
+
+  // ====================================================================================
+  // Rules can't be edited
+  await capPage.goto()
+  await capPage.open({title:'Pod Privileged Policy'})
+  await capPage.selectTab('Rules')
+  await expect(page.locator('section#rules').locator('input').first()).toBeDisabled()
+});

--- a/tests/e2e/pages/basepolicypage.ts
+++ b/tests/e2e/pages/basepolicypage.ts
@@ -69,13 +69,13 @@ export class BasePolicyPage extends BasePage {
 
   async setValues(p: Policy) {
     // Fill general values
-    if (p.name) await this.setName(p.name)
-    if (p.server) await this.setServer(p.server)
+    if (p.name != null) await this.setName(p.name)
+    if (p.server != null) await this.setServer(p.server)
     if (p.mode) await this.setMode(p.mode)
-    if (p.module) await this.setModule(p.module)
+    if (p.module != null) await this.setModule(p.module)
 
     // Fill Admission | ClusterAdmission specific fields
-    if ('namespace' in p && p.namespace)
+    if ('namespace' in p && p.namespace != null)
       await this.setNamespace(p.namespace)
     if ('ignoreRancherNS' in p && p.ignoreRancherNS)
       await this.setIgnoreRancherNS(p.ignoreRancherNS)

--- a/tests/e2e/pages/basepolicypage.ts
+++ b/tests/e2e/pages/basepolicypage.ts
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test';
 import { BasePage } from './basepage';
 import { RancherUI } from './rancher-ui';
+import type { Locator, Page } from '@playwright/test';
+import { TableRow } from '../components/table-row';
 
 export const policyTitles = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP',
   'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
@@ -9,7 +11,7 @@ export const policyTitles = ['Custom Policy', 'Allow Privilege Escalation PSP', 
 
 export interface Policy {
   title: typeof policyTitles[number]
-  name: string
+  name?: string
   mode?: 'Monitor'|'Protect'
   server?: string
   module?: string
@@ -24,7 +26,7 @@ export function generateName(title: string) {
 
 export class BasePolicyPage extends BasePage {
 
-  async selectTab(name: 'General'|'Rules'|'Settings') {
+  async selectTab(name: 'General'|'Rules'|'Settings'|'Context Aware Resources') {
     await this.page.getByRole('tab', { name: name, exact: true }).click()
     await expect(this.page.locator('.tab-header').getByRole('heading', {name: name})).toBeVisible()
   }
@@ -55,16 +57,19 @@ export class BasePolicyPage extends BasePage {
     await this.page.getByRole('heading', {name:'Ignore Rancher'}).locator('xpath=../..').getByRole('radio', {name: option}).check()
   }
 
-  async create(p: Policy, options?: { wait: boolean}) {
+  async open(p: Policy) {
+    // Start from policies list
     await this.ui.createBtn.click()
     await expect(this.page.getByRole('heading', { name: 'Finish: Step 1' })).toBeVisible()
 
     // Select policy, skip readme
     await this.page.getByRole('heading', { name: p.title, exact: true }).click()
     await this.page.getByRole('tab', { name: 'Values' }).click()
+  }
 
+  async setValues(p: Policy) {
     // Fill general values
-    await this.setName(p.name)
+    if (p.name) await this.setName(p.name)
     if (p.server) await this.setServer(p.server)
     if (p.mode) await this.setMode(p.mode)
     if (p.module) await this.setModule(p.module)
@@ -83,6 +88,19 @@ export class BasePolicyPage extends BasePage {
       // Show yaml with edited settings
       await this.page.getByRole('button', { name: 'Edit YAML' }).click()
     }
+  }
+
+  async updateToProtect(row: TableRow) {
+    await row.action('Update Mode')
+    await this.ui.checkbox('Update to Protect Mode').check()
+    await this.page.getByRole('button', {name: 'Save', exact: true}).click()
+    await expect(row.column('Mode')).toHaveText('Protect')
+  }
+
+  async create(p: Policy, options?: { wait: boolean}) {
+    p.name ??= generateName(p.title)
+    await this.open(p)
+    await this.setValues(p)
 
     // Create policy - redirects to policies list
     await this.page.getByRole('button', { name: 'Finish' }).click()
@@ -93,6 +111,7 @@ export class BasePolicyPage extends BasePage {
     if (options?.wait) {
       await expect(polRow.column('Status')).toHaveText('Active', {timeout: 200_000})
     }
+    return polRow
   }
 
 }

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -18,7 +18,7 @@ export class KubewardenPage extends BasePage {
     const failRepoBtn = this.page.getByRole('button', { name: 'Reload', exact: true });
 
     // Welcome screen
-    await this.page.goto('dashboard/c/local/kubewarden');
+    await this.goto();
     await expect(welcomeStep).toBeVisible();
     await installBtn.click();
 

--- a/tests/e2e/pages/policyservers.page.ts
+++ b/tests/e2e/pages/policyservers.page.ts
@@ -20,6 +20,7 @@ export class PolicyServersPage extends BasePage {
     if (options?.wait) {
       await expect(psRow.status).toHaveText('Active', {timeout: 60_000})
     }
+    return psRow
   }
 
   async delete(name: string) {

--- a/tests/e2e/pages/rancher-common.page.ts
+++ b/tests/e2e/pages/rancher-common.page.ts
@@ -61,6 +61,14 @@ export class RancherCommonPage extends BasePage {
     await nsDropdown.locator('i.icon-chevron-up').click()
   }
 
+  async setHelmCharts(option: 'Show Releases Only'|'Include Prerelease Versions') {
+    await this.page.goto('/dashboard/prefs')
+    const btn = this.page.getByRole('button', {name: option, exact: true})
+    await btn.click()
+    await expect(btn).toHaveClass(/bg-primary/)
+    await this.page.waitForTimeout(100)
+  }
+
   /**
    * Change user preferences
    * @param checked Switch developer features on | off

--- a/tests/e2e/policyservers.spec.ts
+++ b/tests/e2e/policyservers.spec.ts
@@ -8,7 +8,8 @@ const expect3m = expect.configure({timeout: 3*60_000})
 
 test('Policy Servers ', async({ page, ui }) => {
   const serverName = 'test-policyserver'
-  const policy: Policy = {title: 'Pod Privileged Policy', name: 'test-policy-podpriv', server: serverName}
+  const policyName = 'test-policy-podpriv'
+  const policy: Policy = {title: 'Pod Privileged Policy', name: policyName, server: serverName}
 
   const psPage = new PolicyServersPage(page)
   const apPage = new AdmissionPoliciesPage(page)
@@ -35,8 +36,8 @@ test('Policy Servers ', async({ page, ui }) => {
 
   // Check Policy Server details page
   await psRow.open()
-  const apRow = ui.getRow(policy.name, {group: 'AdmissionPolicy'})
-  const capRow = ui.getRow(policy.name, {group: 'ClusterAdmissionPolicy'})
+  const apRow = ui.getRow(policyName, {group: 'AdmissionPolicy'})
+  const capRow = ui.getRow(policyName, {group: 'ClusterAdmissionPolicy'})
   await expect3m(apRow.column('Status')).toHaveText('Active')
   await expect3m(capRow.column('Status')).toHaveText('Active')
 


### PR DESCRIPTION
- Add Cluster Admission Policies test
- Enable policy servers test
- Update policies model, split create policy function into opening policy, filling values and creation
- add function to switch policy into protect mode
- add function to enable pre-release helm charts (allows update of kw after initial installation)
- return new table row after resource creation